### PR TITLE
Add automated GUI Testing for HelpWindow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
+    String testFxVersion = '4.0.15-alpha'
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 
@@ -59,6 +60,11 @@ dependencies {
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
+
+    // Adapted from https://github.com/TestFX/TestFX
+    testImplementation group: 'org.testfx', name: 'testfx-core', version: testFxVersion
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+    testImplementation "org.testfx:testfx-junit5:4.0.16-alpha"
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -89,6 +89,13 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
     /**
+     * Returns true if the help window is currently being hidden.
+     */
+    public boolean isHiding() {
+        return !getRoot().isShowing();
+    }
+
+    /**
      * Hides the help window.
      */
     public void hide() {

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -1,0 +1,100 @@
+package guitests;
+
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+import org.testfx.api.FxRobot;
+
+import guitests.exceptions.StageNotFoundException;
+import javafx.stage.Stage;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/guitests/GuiRobot.java
+
+/**
+ * Robot used to simulate user actions on the GUI.
+ * Extends {@link FxRobot} by adding some customized functionality and workarounds.
+ */
+public class GuiRobot extends FxRobot {
+
+    private static final int PAUSE_FOR_HUMAN_DELAY_MILLISECONDS = 250;
+    private static final int DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS = 5000;
+
+    /**
+     * Pauses execution for {@code PAUSE_FOR_HUMAN_DELAY_MILLISECONDS} milliseconds for a human to examine the
+     * effects of the test.
+     */
+    public void pauseForHuman() {
+        sleep(PAUSE_FOR_HUMAN_DELAY_MILLISECONDS);
+    }
+
+    /**
+     * Waits for {@code event} to be true by {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS} milliseconds (ms).
+     *
+     * @throws EventTimeoutException if time taken exceeds {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS} ms.
+     */
+    public void waitForEvent(BooleanSupplier event) {
+        waitForEvent(event, DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS);
+    }
+
+    /**
+     * Waits for {@code event} to be true.
+     *
+     * @param timeOut in milliseconds
+     * @throws EventTimeoutException if the time taken exceeds {@code timeOut}.
+     */
+    public void waitForEvent(BooleanSupplier event, int timeOut) {
+        int timePassed = 0;
+        final int retryInterval = 50;
+
+        while (!event.getAsBoolean()) {
+            sleep(retryInterval);
+            timePassed += retryInterval;
+
+            if (timePassed >= timeOut) {
+                throw new EventTimeoutException();
+            }
+        }
+
+        pauseForHuman();
+    }
+
+    /**
+     * Returns true if the window with {@code stageTitle} is currently open.
+     */
+    public boolean isWindowShown(String stageTitle) {
+        return getNumberOfWindowsShown(stageTitle) >= 1;
+    }
+
+    /**
+     * Returns the number of windows with {@code stageTitle} that are currently open.
+     */
+    public int getNumberOfWindowsShown(String stageTitle) {
+        return (int) listTargetWindows().stream()
+                .filter(window -> window instanceof Stage && ((Stage) window).getTitle().equals(stageTitle))
+                .count();
+    }
+
+    /**
+     * Returns the first stage, ordered by proximity to the current target window, with the stage title.
+     * The order that the windows are searched are as follows (proximity): current target window,
+     * children of the target window, rest of the windows.
+     *
+     * @throws StageNotFoundException if the stage is not found.
+     */
+    public Stage getStage(String stageTitle) {
+        Optional<Stage> targetStage = listTargetWindows().stream()
+                .filter(Stage.class::isInstance) // checks that the window is of type Stage
+                .map(Stage.class::cast)
+                .filter(stage -> stage.getTitle().equals(stageTitle))
+                .findFirst();
+
+        return targetStage.orElseThrow(StageNotFoundException::new);
+    }
+
+    /**
+     * Represents an error which occurs when a timeout occurs when waiting for an event.
+     */
+    private class EventTimeoutException extends RuntimeException {
+    }
+}

--- a/src/test/java/guitests/exceptions/NodeNotFoundException.java
+++ b/src/test/java/guitests/exceptions/NodeNotFoundException.java
@@ -1,0 +1,13 @@
+package guitests.exceptions;
+
+import java.util.NoSuchElementException;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/
+// guitests/guihandles/exceptions/NodeNotFoundException.java
+
+/**
+ * Signals that the node cannot be found.
+ */
+public class NodeNotFoundException extends NoSuchElementException {
+}

--- a/src/test/java/guitests/exceptions/StageNotFoundException.java
+++ b/src/test/java/guitests/exceptions/StageNotFoundException.java
@@ -1,0 +1,13 @@
+package guitests.exceptions;
+
+import java.util.NoSuchElementException;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/
+// guitests/guihandles/exceptions/StageNotFoundException.java
+
+/**
+ * Signals that the stage cannot be found.
+ */
+public class StageNotFoundException extends NoSuchElementException {
+}

--- a/src/test/java/seedu/address/ui/GuiUnitTest.java
+++ b/src/test/java/seedu/address/ui/GuiUnitTest.java
@@ -1,0 +1,35 @@
+package seedu.address.ui;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import guitests.GuiRobot;
+import guitests.exceptions.NodeNotFoundException;
+import javafx.scene.Node;
+import seedu.address.ui.testutil.UiPartExtension;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/seedu/address/ui/GuiUnitTest.java
+
+/**
+ * A GUI unit test class for AddressBook.
+ */
+public abstract class GuiUnitTest {
+
+    @RegisterExtension
+    public final UiPartExtension uiPartExtension = new UiPartExtension();
+
+    protected final GuiRobot guiRobot = new GuiRobot();
+
+    /**
+     * Retrieves the {@code query} node owned by the {@code rootNode}.
+     *
+     * @param query name of the CSS selector of the node to retrieve.
+     * @throws NodeNotFoundException if no such node exists.
+     */
+    protected <T extends Node> T getChildNode(Node rootNode, String query) {
+        Optional<T> node = guiRobot.from(rootNode).lookup(query).tryQuery();
+        return node.orElseThrow(NodeNotFoundException::new);
+    }
+}

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,0 +1,75 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testfx.api.FxToolkit;
+
+import javafx.stage.Stage;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/
+// seedu/address/ui/HelpWindowTest.java
+// with minor modifications.
+
+/**
+ * Test class for HelpWindow.
+ */
+public class HelpWindowTest extends GuiUnitTest {
+
+    private HelpWindow helpWindow;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        guiRobot.interact(() -> helpWindow = new HelpWindow());
+        FxToolkit.registerStage(helpWindow::getRoot);
+    }
+
+    /**
+     * Tests the behaviour of help window when it is opened.
+     */
+    @Test
+    public void isShowing_helpWindowIsShowing_returnsTrue() {
+        guiRobot.interact(helpWindow::show);
+        assertTrue(helpWindow.isShowing());
+    }
+
+    /**
+     * Tests the behaviour of help window when it is not opened.
+     */
+    @Test
+    public void isShowing_helpWindowIsHiding_returnsFalse() {
+        assertFalse(helpWindow.isShowing());
+    }
+
+    /**
+     * Tests the behaviour of help window when it is hidden.
+     */
+    @Test
+    public void isHiding_helpWindowHidden_returnsTrue() {
+        guiRobot.interact(helpWindow::hide);
+        assertTrue(helpWindow.isHiding());
+    }
+
+    /**
+     * Tests the behaviour of help window in focus and not in focus.
+     * When there is a focus on another stage, the focus on the help window should be removed.
+     * When the focus is set on the help window again, it should be focused.
+     */
+    @Test
+    public void focus_helpWindowNotFocused_focused() {
+        guiRobot.interact(helpWindow::show);
+
+        guiRobot.interact(() -> {
+            Stage temporaryStage = new Stage();
+            temporaryStage.show();
+            temporaryStage.requestFocus();
+        });
+        assertFalse(helpWindow.getRoot().isFocused());
+
+        guiRobot.interact(helpWindow::focus);
+        assertTrue(helpWindow.getRoot().isFocused());
+    }
+}

--- a/src/test/java/seedu/address/ui/testutil/StageExtension.java
+++ b/src/test/java/seedu/address/ui/testutil/StageExtension.java
@@ -1,0 +1,26 @@
+package seedu.address.ui.testutil;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testfx.api.FxToolkit;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/
+// seedu/address/ui/testutil/StageExtension.java
+
+/**
+ * Properly sets up and tears down a JavaFx stage for our testing purposes.
+ */
+public class StageExtension implements BeforeEachCallback, AfterEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        FxToolkit.cleanupStages();
+    }
+}
+

--- a/src/test/java/seedu/address/ui/testutil/UiPartExtension.java
+++ b/src/test/java/seedu/address/ui/testutil/UiPartExtension.java
@@ -1,0 +1,33 @@
+package seedu.address.ui.testutil;
+
+import java.util.concurrent.TimeoutException;
+
+import org.testfx.api.FxToolkit;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import seedu.address.ui.UiPart;
+
+//@@author carriezhengjr-reused
+//Reused from https://github.com/se-edu/addressbook-level4/blob/master/src/test/java/
+// seedu/address/ui/testutil/UiPartExtension.java
+
+/**
+ * Provides an isolated stage to test an individual {@code UiPart}.
+ */
+public class UiPartExtension extends StageExtension {
+    private static final String[] CSS_FILES = {"view/DarkTheme.css", "view/Extensions.css"};
+
+    public void setUiPart(final UiPart<? extends Parent> uiPart) {
+        try {
+            FxToolkit.setupScene(() -> {
+                Scene scene = new Scene(uiPart.getRoot());
+                scene.getStylesheets().setAll(CSS_FILES);
+                return scene;
+            });
+            FxToolkit.showStage();
+        } catch (TimeoutException te) {
+            throw new AssertionError("Timeout should not happen.", te);
+        }
+    }
+}


### PR DESCRIPTION
There is no test for methods in HelpWindow, which resulted in a failed codecov/patch check when changes are made and committed.

Adding automated GUI Tests could increase test coverage for HelpWindow class and pass codecov/patch check.
However, it is difficult to write such test cases.

Let's add tests for HelpWindow by
* reusing codes from Address Book (Level 4) for now and
* modify accordingly to suit our project.

Fixes #61 .