### PR TITLE
Increase find functionality

### DIFF
--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -17,16 +17,29 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
+
+        boolean isPerson = false;
+
+        if (person.getPhone() != null) {
+            isPerson = isPerson || keywords.stream().anyMatch
+                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getPhone().toString(), keyword));
+        }
+
+        if (person.getEmail() != null) {
+            isPerson = isPerson || keywords.stream().anyMatch
+                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getEmail().toString(), keyword));
+        }
+
+        if (person.getGitHub() != null) {
+            isPerson = isPerson || keywords.stream().anyMatch
+                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getGitHub().username, keyword));
+        }
+
+        return isPerson
+                || keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword))
                 || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getPhone().toString(), keyword))
-                || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getEmail().toString(), keyword))
-                || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getTelegram().toString(), keyword))
-                || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getGitHub().username, keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getTelegram().toString(), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -21,25 +21,26 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         boolean isPerson = false;
 
         if (person.getPhone() != null) {
-            isPerson = isPerson || keywords.stream().anyMatch
-                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getPhone().toString(), keyword));
+            isPerson = isPerson || keywords.stream().anyMatch(
+                    keyword -> StringUtil.containsPartialWordIgnoreCase(person.getPhone().toString(), keyword));
         }
 
         if (person.getEmail() != null) {
-            isPerson = isPerson || keywords.stream().anyMatch
-                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getEmail().toString(), keyword));
+            isPerson = isPerson || keywords.stream().anyMatch(
+                    keyword -> StringUtil.containsPartialWordIgnoreCase(person.getEmail().toString(), keyword));
         }
 
         if (person.getGitHub() != null) {
-            isPerson = isPerson || keywords.stream().anyMatch
-                    (keyword -> StringUtil.containsPartialWordIgnoreCase(person.getGitHub().username, keyword));
+            isPerson = isPerson || keywords.stream().anyMatch(
+                    keyword -> StringUtil.containsPartialWordIgnoreCase(person.getGitHub().username, keyword));
         }
 
         return isPerson
                 || keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword))
                 || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getTelegram().toString(), keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getTelegram().toString(), keyword)
+                );
     }
 
     @Override


### PR DESCRIPTION
Able to search for students with phone number, email, telegram handle and github that contains the keywords, need not be completely matching i.e. keywords may be a partial form of the search fields.

For instance, find "999" gives individuals whose phone numbers are "69998888", "89991234", "99912347" etc as long as the phone numbers contain "999". Ditto to email, telegram handle and github.

Fix bugs by considering null fields.