### PR TITLE
Mod mark

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ModAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModAddCommand.java
@@ -24,9 +24,9 @@ public class ModAddCommand extends ModCommand {
     private final ObservableList<Mod> mods;
 
     /**
-     * Constructs a command that adds a set of mods to the person
+     * Constructs a command that adds a set of mods to the batchmate
      * with the target index.
-     * @param index The index of the person to add to.
+     * @param index The index of the batchmate to add to.
      * @param mods The set of mods to add to.
      */
     public ModAddCommand(Index index, ObservableList<Mod> mods) {

--- a/src/main/java/seedu/address/logic/commands/ModCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModCommand.java
@@ -11,9 +11,10 @@ public abstract class ModCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Modifies the modules related to a batchmate. "
             + "\nParameters: INDEX (must be a positive integer) MODULE [MORE_MODULES]..."
             + "\nExamples:"
-            + "\nmod add INDEX MODULE [MORE_MODULES]... : Adds the entered mods to the batchmate at the index"
-            + "\nmod delete INDEX MODULE [MORE_MODULES]... : Deletes the entered mods from the batchmate at the index"
-            + "\nmod mark INDEX MODULE [MORE_MODULES]... : Marks the entered mods of the batchmate at the index as taken";
+            + "\nmod add INDEX MODULE [MORE_MODULES]... : Adds the entered mods to the batchmate at the index."
+            + "\nmod delete INDEX MODULE [MORE_MODULES]... : Deletes the entered mods from the batchmate at the index."
+            + "\nmod mark INDEX MODULE [MORE_MODULES]... : Marks the entered mods of the batchmate "
+            + "at the index as taken";
     public static final String MESSAGE_MODS_EMPTY = "Mods cannot be empty!";
     public static final String MESSAGE_INDEX_EMPTY = "Index cannot be empty!";
 }

--- a/src/main/java/seedu/address/logic/commands/ModCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModCommand.java
@@ -2,17 +2,18 @@ package seedu.address.logic.commands;
 
 /**
  * Represents a command that modifies the mod attribute of the
- * person identified.
+ * batchmate identified.
  */
 public abstract class ModCommand extends Command {
 
     public static final String COMMAND_WORD = "mod";
     // TODO: Add the other mod commands
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Modifies the modules related to a person. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Modifies the modules related to a batchmate. "
             + "\nParameters: INDEX (must be a positive integer) MODULE [MORE_MODULES]..."
             + "\nExamples:"
-            + "\nmod add INDEX MODULE [MORE_MODULES]... : Adds the entered mods to the person at the index"
-            + "\nmod delete INDEX MODULE [MORE_MODULES]... : Deletes the entered mods from the person at the index";
+            + "\nmod add INDEX MODULE [MORE_MODULES]... : Adds the entered mods to the batchmate at the index"
+            + "\nmod delete INDEX MODULE [MORE_MODULES]... : Deletes the entered mods from the batchmate at the index"
+            + "\nmod mark INDEX MODULE [MORE_MODULES]... : Marks the entered mods of the batchmate at the index as taken";
     public static final String MESSAGE_MODS_EMPTY = "Mods cannot be empty!";
     public static final String MESSAGE_INDEX_EMPTY = "Index cannot be empty!";
 }

--- a/src/main/java/seedu/address/logic/commands/ModCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModCommand.java
@@ -14,7 +14,7 @@ public abstract class ModCommand extends Command {
             + "\nmod add INDEX MODULE [MORE_MODULES]... : Adds the entered mods to the batchmate at the index."
             + "\nmod delete INDEX MODULE [MORE_MODULES]... : Deletes the entered mods from the batchmate at the index."
             + "\nmod mark INDEX MODULE [MORE_MODULES]... : Marks the entered mods of the batchmate "
-            + "at the index as taken";
+            + "at the index as taken.";
     public static final String MESSAGE_MODS_EMPTY = "Mods cannot be empty!";
     public static final String MESSAGE_INDEX_EMPTY = "Index cannot be empty!";
 }

--- a/src/main/java/seedu/address/logic/commands/ModDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModDeleteCommand.java
@@ -26,7 +26,8 @@ public class ModDeleteCommand extends ModCommand {
 
     /**
      * Constructs a command that deletes all mods specified from the list of the batchmate at the target index.
-     * @param index The index of the batchmate to add to.
+     *
+     * @param index The index of the batchmate.
      * @param mods The set of mods to be deleted.
      */
     public ModDeleteCommand(Index index, ObservableList<Mod> mods) {

--- a/src/main/java/seedu/address/logic/commands/ModDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModDeleteCommand.java
@@ -13,20 +13,20 @@ import seedu.address.model.person.Mod;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes mods from the person specified.
+ * Deletes mods from the batchmate specified.
  */
 public class ModDeleteCommand extends ModCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_SUCCESS = "Successfully deleted the specified mods.";
-    public static final String MESSAGE_INVALID_MOD = "This person is not taking all of the modules specified."
-            + "\nPlease check your list of mods and try again.";
+    public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified."
+            + "\nPlease check the list of mods and try again.";
     private final Index targetIndex;
     private final ObservableList<Mod> mods;
 
     /**
-     * Constructs a command that deletes all mods specified from the list of the person at the target index.
-     * @param index The index of the person to add to.
+     * Constructs a command that deletes all mods specified from the list of the batchmate at the target index.
+     * @param index The index of the batchmate to add to.
      * @param mods The set of mods to be deleted.
      */
     public ModDeleteCommand(Index index, ObservableList<Mod> mods) {
@@ -55,7 +55,7 @@ public class ModDeleteCommand extends ModCommand {
 
         Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
 
-        if (personToEdit.canDeleteMods(mods)) {
+        if (personToEdit.canEditMods(mods)) {
             personToEdit.deleteMods(mods);
         } else {
             throw new CommandException(MESSAGE_INVALID_MOD);

--- a/src/main/java/seedu/address/logic/commands/ModMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModMarkCommand.java
@@ -26,7 +26,8 @@ public class ModMarkCommand extends ModCommand {
 
     /**
      * Constructs a command that marks all mods specified at the target batchmate as taken.
-     * @param index The index of the batchmate to add to.
+     *
+     * @param index The index of the batchmate.
      * @param mods The set of mods to be marked.
      */
     public ModMarkCommand(Index index, ObservableList<Mod> mods) {
@@ -55,8 +56,6 @@ public class ModMarkCommand extends ModCommand {
 
         Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
 
-        // TODO: To be improved to check if each mod exists;
-        //  mark existing mods as taken and show error message for non-existing mods.
         if (personToEdit.canEditMods(mods)) {
             personToEdit.markMods(mods);
         } else {
@@ -74,7 +73,7 @@ public class ModMarkCommand extends ModCommand {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof ModDeleteCommand)) {
+        if (!(other instanceof ModMarkCommand)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/logic/commands/ModMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModMarkCommand.java
@@ -11,25 +11,25 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Mod;
 import seedu.address.model.person.Person;
-import seedu.address.ui.MainWindow;
 
 /**
- * Appends new mods to the batchmate.
+ * Marks mods of the batchmate specified as taken.
  */
-public class ModAddCommand extends ModCommand {
-    public static final String COMMAND_WORD = "add";
-    public static final String MESSAGE_SUCCESS = "Successfully added the specified mods.";
-    private MainWindow mainWindow;
+public class ModMarkCommand extends ModCommand {
+
+    public static final String COMMAND_WORD = "mark";
+    public static final String MESSAGE_SUCCESS = "Successfully marked the specified mods.";
+    public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified."
+            + "\nPlease check the list of mods and try again.";
     private final Index targetIndex;
     private final ObservableList<Mod> mods;
 
     /**
-     * Constructs a command that adds a set of mods to the person
-     * with the target index.
-     * @param index The index of the person to add to.
-     * @param mods The set of mods to add to.
+     * Constructs a command that marks all mods specified at the target batchmate as taken.
+     * @param index The index of the batchmate to add to.
+     * @param mods The set of mods to be marked.
      */
-    public ModAddCommand(Index index, ObservableList<Mod> mods) {
+    public ModMarkCommand(Index index, ObservableList<Mod> mods) {
         requireNonNull(index);
         requireNonNull(mods);
 
@@ -54,7 +54,15 @@ public class ModAddCommand extends ModCommand {
         }
 
         Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
-        personToEdit.addMods(mods);
+
+        // TODO: To be improved to check if each mod exists;
+        //  mark existing mods as taken and show error message for non-existing mods.
+        if (personToEdit.canEditMods(mods)) {
+            personToEdit.markMods(mods);
+        } else {
+            throw new CommandException(MESSAGE_INVALID_MOD);
+        }
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, personToEdit));
     }
 
@@ -66,13 +74,14 @@ public class ModAddCommand extends ModCommand {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof ModAddCommand)) {
+        if (!(other instanceof ModDeleteCommand)) {
             return false;
         }
 
         // state check
-        ModAddCommand e = (ModAddCommand) other;
+        ModMarkCommand e = (ModMarkCommand) other;
         return targetIndex.equals(e.targetIndex)
                 && mods.equals(e.mods);
     }
 }
+

--- a/src/main/java/seedu/address/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModCommandParser.java
@@ -19,6 +19,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ModAddCommand;
 import seedu.address.logic.commands.ModCommand;
 import seedu.address.logic.commands.ModDeleteCommand;
+import seedu.address.logic.commands.ModMarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Mod;
 
@@ -59,6 +60,8 @@ public class ModCommandParser implements Parser<ModCommand> {
             return parseAddCommand(arguments);
         case ModDeleteCommand.COMMAND_WORD:
             return parseDeleteCommand(arguments);
+        case ModMarkCommand.COMMAND_WORD:
+            return parseMarkCommand(arguments);
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModCommand.MESSAGE_USAGE));
         }
@@ -98,6 +101,24 @@ public class ModCommandParser implements Parser<ModCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE), pe);
         }
         return new ModDeleteCommand(index, mods.get());
+    }
+
+    private ModMarkCommand parseMarkCommand(String args) throws ParseException {
+        Index index;
+        String trimmedArgs = args.trim();
+        String indexFromCommand = getIndexFromCommand(trimmedArgs);
+        Set<String> modsFromCommand = getModsFromCommand(trimmedArgs);
+        Optional<ObservableList<Mod>> mods = parseMods(modsFromCommand);
+        if (mods.isEmpty()) {
+            throw new ParseException(ModCommand.MESSAGE_MODS_EMPTY);
+        }
+
+        try {
+            index = ParserUtil.parseIndex(indexFromCommand);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE), pe);
+        }
+        return new ModMarkCommand(index, mods.get());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModCommandParser.java
@@ -98,7 +98,7 @@ public class ModCommandParser implements Parser<ModCommand> {
         try {
             index = ParserUtil.parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModDeleteCommand.MESSAGE_USAGE), pe);
         }
         return new ModDeleteCommand(index, mods.get());
     }
@@ -116,7 +116,7 @@ public class ModCommandParser implements Parser<ModCommand> {
         try {
             index = ParserUtil.parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE), pe);
         }
         return new ModMarkCommand(index, mods.get());
     }

--- a/src/main/java/seedu/address/model/person/Mod.java
+++ b/src/main/java/seedu/address/model/person/Mod.java
@@ -12,7 +12,7 @@ public class Mod {
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String modName;
-    public boolean hasTaken;
+    private boolean hasTaken;
 
     /**
      * Constructs a {@code Mod}.

--- a/src/main/java/seedu/address/model/person/Mod.java
+++ b/src/main/java/seedu/address/model/person/Mod.java
@@ -13,6 +13,8 @@ public class Mod {
 
     public final String modName;
 
+    public boolean hasTaken;
+
     /**
      * Constructs a {@code Mod}.
      *
@@ -22,6 +24,20 @@ public class Mod {
         requireNonNull(modName);
         checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
         this.modName = modName;
+        this.hasTaken = false;
+    }
+
+    /**
+     * Constructs a {@code Mod} with name and status.
+     *
+     * @param modName A valid mod name.
+     * @param hasTaken The mod status.
+     */
+    public Mod(String modName, boolean hasTaken) {
+        requireNonNull(modName);
+        checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
+        this.modName = modName;
+        this.hasTaken = hasTaken;
     }
 
     /**
@@ -44,6 +60,29 @@ public class Mod {
                 && otherMod.modName.equals((this.modName));
     }
 
+    /**
+     * Marks a module as taken.
+     */
+    public void markMod() {
+        this.hasTaken = true;
+    }
+
+    /**
+     * Unmarks a module as not taken.
+     */
+    public void unmarkMod() {
+        this.hasTaken = false;
+    }
+
+    /**
+     * Gets the status of the module.
+     *
+     * @return True if the batchmate has taken the mod; false otherwise
+     */
+    public boolean getModStatus() {
+        return this.hasTaken;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
@@ -60,6 +99,6 @@ public class Mod {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + modName + ']';
+        return '[' + modName + ": " + hasTaken + ']';
     }
 }

--- a/src/main/java/seedu/address/model/person/Mod.java
+++ b/src/main/java/seedu/address/model/person/Mod.java
@@ -12,7 +12,6 @@ public class Mod {
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String modName;
-
     public boolean hasTaken;
 
     /**
@@ -23,20 +22,20 @@ public class Mod {
     public Mod(String modName) {
         requireNonNull(modName);
         checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
-        this.modName = modName;
+        this.modName = modName.toUpperCase();
         this.hasTaken = false;
     }
 
     /**
-     * Constructs a {@code Mod} with name and status.
+     * Constructs a {@code Mod} with name and hasTaken status.
      *
      * @param modName A valid mod name.
-     * @param hasTaken The mod status.
+     * @param hasTaken The mod status, i.e. whether it has been taken.
      */
     public Mod(String modName, boolean hasTaken) {
         requireNonNull(modName);
         checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
-        this.modName = modName;
+        this.modName = modName.toUpperCase();
         this.hasTaken = hasTaken;
     }
 
@@ -75,9 +74,18 @@ public class Mod {
     }
 
     /**
+     * Gets the module name.
+     *
+     * @return String representation of module name.
+     */
+    public String getModName() {
+        return this.modName;
+    }
+
+    /**
      * Gets the status of the module.
      *
-     * @return True if the batchmate has taken the mod; false otherwise
+     * @return True if the batchmate has taken the mod; false otherwise.
      */
     public boolean getModStatus() {
         return this.hasTaken;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -128,9 +128,8 @@ public class Person {
 
                 if (currentModName.equals(targetModName)) {
                     currentMod.markMod();
-                    i++;
+                    break;
                 }
-                j++;
             }
         }
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -82,18 +82,6 @@ public class Person {
     }
 
     /**
-     * Returns an immutable mods status set, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
-     */
-    public ObservableList<Boolean> getStatus() {
-        final ObservableList<Boolean> hasTaken = FXCollections.observableArrayList();
-        mods.forEach((mod) -> {
-            hasTaken.add(mod.getModStatus());
-        });
-        return FXCollections.unmodifiableObservableList(hasTaken);
-    }
-
-    /**
      * Appends a set of mods to the current mods linked to this batchmate.
      *
      * @param mods The set of mods to add in.
@@ -131,9 +119,20 @@ public class Person {
      * @param mods The set of mods to be marked.
      */
     public void markMods(ObservableList<Mod> mods) {
-        mods.forEach((mod) -> {
-            mod.markMod();
-        });
+        for (int i = 0; i < mods.size(); i++) {
+            for (int j = 0; j < this.mods.size(); j++) {
+
+                Mod currentMod = this.mods.get(j);
+                String currentModName = currentMod.modName;
+                String targetModName = mods.get(i).modName;
+
+                if (currentModName.equals(targetModName)) {
+                    currentMod.markMod();
+                    i++;
+                }
+                j++;
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -82,7 +82,19 @@ public class Person {
     }
 
     /**
-     * Appends a set of mods to the current mods linked to this person.
+     * Returns an immutable mods status set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public ObservableList<Boolean> getStatus() {
+        final ObservableList<Boolean> hasTaken = FXCollections.observableArrayList();
+        mods.forEach((mod) -> {
+            hasTaken.add(mod.getModStatus());
+        });
+        return FXCollections.unmodifiableObservableList(hasTaken);
+    }
+
+    /**
+     * Appends a set of mods to the current mods linked to this batchmate.
      *
      * @param mods The set of mods to add in.
      */
@@ -96,21 +108,32 @@ public class Person {
     }
 
     /**
-     * Checks if the all mods provided can be found and deleted in the set of mods linked to this person.
+     * Checks if the all mods provided can be found and edited in the set of mods linked to this batchmate.
      *
-     * @param mods The set of mods to be deleted.
+     * @param mods The set of mods to be edited.
      */
-    public boolean canDeleteMods(ObservableList<Mod> mods) {
+    public boolean canEditMods(ObservableList<Mod> mods) {
         return this.mods.containsAll(mods);
     }
 
     /**
-     * Removes all mods in {@code mods} from the current set of mods linked to this person.
+     * Removes all mods in {@code mods} from the current set of mods linked to this batchmate.
      *
      * @param mods The set of mods to be deleted.
      */
     public void deleteMods(ObservableList<Mod> mods) {
         this.mods.removeAll(mods);
+    }
+
+    /**
+     * Marks all mods in {@code mods} in the current set of mods linked to this batchmate as taken.
+     *
+     * @param mods The set of mods to be marked.
+     */
+    public void markMods(ObservableList<Mod> mods) {
+        mods.forEach((mod) -> {
+            mod.markMod();
+        });
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedMod.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMod.java
@@ -1,7 +1,7 @@
 package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Mod;
@@ -15,25 +15,22 @@ class JsonAdaptedMod {
     private boolean hasTaken;
 
     /**
-     * Constructs a {@code JsonAdaptedMod} with the given {@code modName}.
+     * Constructs a {@code JsonAdaptedMod} with the given module details.
      */
     @JsonCreator
-    public JsonAdaptedMod(String modName) {
+    public JsonAdaptedMod(@JsonProperty("modName") String modName,
+                          @JsonProperty("hasTaken") boolean hasTaken) {
         this.modName = modName;
+        this.hasTaken = hasTaken;
     }
 
     /**
      * Converts a given {@code Mod} into this class for Jackson use.
      */
     public JsonAdaptedMod(Mod source) {
-        modName = source.modName;
-        hasTaken = source.hasTaken;
+        modName = source.getModName();
+        hasTaken = source.getModStatus();
     }
-
-//    @JsonValue
-//    public String getModName() {
-//        return modName;
-//    }
 
     /**
      * Converts this Jackson-friendly adapted mod object into the model's {@code Mod} object.

--- a/src/main/java/seedu/address/storage/JsonAdaptedMod.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMod.java
@@ -12,6 +12,7 @@ import seedu.address.model.person.Mod;
 class JsonAdaptedMod {
 
     private final String modName;
+    private boolean hasTaken;
 
     /**
      * Constructs a {@code JsonAdaptedMod} with the given {@code modName}.
@@ -26,12 +27,13 @@ class JsonAdaptedMod {
      */
     public JsonAdaptedMod(Mod source) {
         modName = source.modName;
+        hasTaken = source.hasTaken;
     }
 
-    @JsonValue
-    public String getModName() {
-        return modName;
-    }
+//    @JsonValue
+//    public String getModName() {
+//        return modName;
+//    }
 
     /**
      * Converts this Jackson-friendly adapted mod object into the model's {@code Mod} object.
@@ -42,7 +44,7 @@ class JsonAdaptedMod {
         if (!Mod.isValidModName(modName)) {
             throw new IllegalValueException(Mod.MESSAGE_CONSTRAINTS);
         }
-        return new Mod(modName);
+        return new Mod(modName, hasTaken);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -53,7 +53,7 @@ class JsonAdaptedPerson {
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
-        if (tagged != null) {
+        if (mods != null) {
             this.mods.addAll(mods);
         }
     }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -3,14 +3,20 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@example.com",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "handle": "valid",
     "username": "valid"
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "handle": "valid",
     "username": "valid"
   } ]

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -3,7 +3,10 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "handle": "invalid",
     "username": "valid"
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -5,7 +5,10 @@
     "email": "alice@example.com",
     "handle": "alice",
     "username": "alifur",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,7 +6,10 @@
     "email" : "alice@example.com",
     "handle" : "alice",
     "username" : "alifur",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -14,7 +17,10 @@
     "email" : "johnd@example.com",
     "handle" : "bensonhaha",
     "username" : "benji",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -22,7 +28,10 @@
     "email" : "heinz@example.com",
     "handle" : "magcarlsen",
     "username" : "carl69",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -30,7 +39,10 @@
     "email" : "cornelia@example.com",
     "handle" : "dannylim",
     "username" : "dashi",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -38,7 +50,10 @@
     "email" : "werner@example.com",
     "handle" : "ellie",
     "username" : "goldl8ol",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -46,7 +61,10 @@
     "email" : "lydia@example.com",
     "handle" : "fionalim",
     "username" : "EDXs",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ ]
   }, {
     "name" : "George Best",
@@ -54,7 +72,10 @@
     "email" : "anna@example.com",
     "handle" : "georgesim",
     "username" : "pizzac0der",
-    "mods" : [ "CS2100" ],
+    "mods" : [ {
+      "modName" : "CS2100",
+      "hasTaken" : false
+    } ],
     "tagged" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/ModMarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModMarkCommandTest.java
@@ -1,0 +1,185 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Mod;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Test class for ModMarkCommand.
+ */
+public class ModMarkCommandTest {
+
+    private static final Mod VALID_MOD_CS2100 = new Mod("CS2100", false);
+    private static final Mod VALID_MOD_CS2101 = new Mod("CS2101", false);
+    private static final Mod VALID_MOD_CS2103 = new Mod("CS2103", false);
+    private static final Mod MOD_NOT_FOUND_CS2105 = new Mod("CS2105", false);
+    private static Model model;
+    private Model expectedModel;
+
+    /**
+     * Sets up the model before each test.
+     */
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when index is not entered.
+     */
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ModMarkCommand(null, FXCollections.observableArrayList()));
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when mod is not entered.
+     */
+    @Test
+    public void constructor_nullMods_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ModMarkCommand(INDEX_FIRST_PERSON, null));
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when the student wants to mark 1 existing mod
+     * in the list of modules of a batchmate.
+     *
+     * @throws CommandException If an error which occurs during execution of ModMarkCommand.
+     */
+    @Test
+    public void execute_markOneMod_success() throws CommandException {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(VALID_MOD_CS2100.modName).build();
+        model.addPerson(batchmate);
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        ModMarkCommand commandToExecute = new ModMarkCommand(indexLastPerson,
+                FXCollections.singletonObservableList(VALID_MOD_CS2100));
+        CommandResult commandResult = commandToExecute.execute(model);
+
+        String actualModStatus = batchmate.getMods().get(0).toString();
+        String expectedModStatus = "[CS2100: true]";
+
+        assertEquals(expectedModStatus, actualModStatus);
+        assertEquals(String.format(ModMarkCommand.MESSAGE_SUCCESS), commandResult.getFeedbackToUser());
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when the student wants to mark 2 existing mods
+     * in the list of modules of a batchmate.
+     *
+     * @throws CommandException If an error which occurs during execution of ModMarkCommand.
+     */
+    @Test
+    public void execute_markMultipleMod_success() throws CommandException {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                VALID_MOD_CS2100.modName,
+                VALID_MOD_CS2103.modName,
+                VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        ModMarkCommand commandToExecute = new ModMarkCommand(indexLastPerson,
+                FXCollections.observableArrayList(VALID_MOD_CS2101, VALID_MOD_CS2100));
+        CommandResult commandResult = commandToExecute.execute(model);
+
+        String actualFirstModStatus = batchmate.getMods().get(0).toString();
+        String actualSecondModStatus = batchmate.getMods().get(1).toString();
+        String actualThirdModStatus = batchmate.getMods().get(2).toString();
+        String actualModStatus = actualFirstModStatus + actualSecondModStatus + actualThirdModStatus;
+
+        String expectedModStatus = "[CS2100: true]" + "[CS2103: false]" + "[CS2101: true]";
+
+        assertEquals(expectedModStatus, actualModStatus);
+        assertEquals(String.format(ModMarkCommand.MESSAGE_SUCCESS), commandResult.getFeedbackToUser());
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when the student wants to mark 1 non-existing mod
+     * in the list of modules of a batchmate.
+     */
+    @Test
+    public void execute_markNonExistingMod1_throwsCommandException() {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                        VALID_MOD_CS2100.modName,
+                        VALID_MOD_CS2103.modName,
+                        VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        try {
+            ModMarkCommand commandToExecute = new ModMarkCommand(indexLastPerson,
+                    FXCollections.observableArrayList(MOD_NOT_FOUND_CS2105));
+            commandToExecute.execute(model);
+            fail(); // Test should not reach this line.
+        } catch (CommandException e) {
+            assertEquals(String.format(ModMarkCommand.MESSAGE_INVALID_MOD), e.getMessage());
+        }
+
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when the student wants to mark multiple mods containing
+     * 1 non-existing mod in the list of modules of a batchmate.
+     */
+    @Test
+    public void execute_markNonExistingMod2_throwsCommandException() {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                        VALID_MOD_CS2100.modName,
+                        VALID_MOD_CS2103.modName,
+                        VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        try {
+            ModMarkCommand commandToExecute = new ModMarkCommand(indexLastPerson,
+                    FXCollections.observableArrayList(VALID_MOD_CS2101, VALID_MOD_CS2103, MOD_NOT_FOUND_CS2105));
+            commandToExecute.execute(model);
+            fail(); // Test should not reach this line.
+        } catch (CommandException e) {
+            assertEquals(String.format(ModMarkCommand.MESSAGE_INVALID_MOD), e.getMessage());
+        }
+
+    }
+
+    /**
+     * Tests the behaviour of ModMarkCommand when index is out of range.
+     *
+     * @throws CommandException If an error which occurs during execution of ModMarkCommand.
+     */
+    @Test
+    public void execute_indexOutOfBounds_throwsCommandException() throws CommandException {
+        Index indexOutOfBounds = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ModMarkCommand invalidCommand = new ModMarkCommand(indexOutOfBounds,
+                FXCollections.singletonObservableList(VALID_MOD_CS2100));
+        assertCommandFailure(invalidCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
@@ -11,6 +11,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ModAddCommand;
+import seedu.address.logic.commands.ModDeleteCommand;
+import seedu.address.logic.commands.ModMarkCommand;
 import seedu.address.logic.commands.ModCommand;
 import seedu.address.model.person.Mod;
 
@@ -86,6 +88,150 @@ public class ModCommandParserTest {
         mods.add(new Mod(VALID_MOD_STRING_CS2103T));
         mods.add(new Mod(VALID_MOD_STRING_CS2101));
         ModAddCommand expectedCommand = new ModAddCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of mod delete when index is absent.
+     */
+    @Test
+    public void parse_noIndexModDelete_throwParseException() {
+        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+                ModCommand.MESSAGE_INDEX_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod delete when mod is absent.
+     */
+    @Test
+    public void parse_noModsModDelete_throwParseException() {
+        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
+                ModCommand.MESSAGE_MODS_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod delete when mod is invalid.
+     */
+    @Test
+    public void parse_invalidModModDelete_throwParseException() {
+        assertParseFailure(parser,
+                ModDeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + INVALID_MOD_STRING,
+                Mod.MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Tests the behaviour of mod delete when index is invalid.
+     */
+    @Test
+    public void parse_invalidIndexModDelete_throwParseException() {
+        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the behaviour of deleting 1 mod.
+     */
+    @Test
+    public void parse_deleteOneMod_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModDeleteCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T;
+
+        ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
+        ModDeleteCommand expectedCommand = new ModDeleteCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of deleting multiple mods.
+     */
+    @Test
+    public void parse_deleteMultipleMods_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModDeleteCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T
+                + " " + VALID_MOD_STRING_CS2101
+                + " " + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModDeleteCommand expectedCommand = new ModDeleteCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of mod mark when index is absent.
+     */
+    @Test
+    public void parse_noIndexModMark_throwParseException() {
+        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+                ModCommand.MESSAGE_INDEX_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod mark when mod is absent.
+     */
+    @Test
+    public void parse_noModsModMark_throwParseException() {
+        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
+                ModCommand.MESSAGE_MODS_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod mark when mod is invalid.
+     */
+    @Test
+    public void parse_invalidModModMark_throwParseException() {
+        assertParseFailure(parser,
+                ModMarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + INVALID_MOD_STRING,
+                Mod.MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Tests the behaviour of mod mark when index is invalid.
+     */
+    @Test
+    public void parse_invalidIndexModMark_throwParseException() {
+        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the behaviour of marking 1 mod as taken.
+     */
+    @Test
+    public void parse_markOneMod_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModMarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T;
+
+        ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
+        ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of marking multiple mods as taken.
+     */
+    @Test
+    public void parse_markMultipleMods_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModMarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T
+                + " " + VALID_MOD_STRING_CS2101
+                + " " + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
@@ -11,9 +11,9 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ModAddCommand;
+import seedu.address.logic.commands.ModCommand;
 import seedu.address.logic.commands.ModDeleteCommand;
 import seedu.address.logic.commands.ModMarkCommand;
-import seedu.address.logic.commands.ModCommand;
 import seedu.address.model.person.Mod;
 
 public class ModCommandParserTest {

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -119,7 +119,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidMods_throwsIllegalValueException() {
         List<JsonAdaptedMod> invalidMods = new ArrayList<>(VALID_MODS);
-        invalidMods.add(new JsonAdaptedMod(INVALID_MOD));
+        invalidMods.add(new JsonAdaptedMod(INVALID_MOD, false));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                         VALID_TELEGRAM, VALID_GITHUB, VALID_TAGS, invalidMods);


### PR DESCRIPTION
Add `mod mark` command to allow the student to mark module(s) of a batchmate as taken. It will also check if all modules entered by student exist in the list of modules.

Tests for the command are not completed yet.

Fixes #79 