### PR TITLE
Add mod unmark command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -173,7 +173,7 @@ Examples:
 
 ### Marking module as taken: `mod mark`
 
-Marks module(s) of a batchmate as `taken`, which means the batchmate has taken or is currently taking the module(s).
+Marks module(s) of a batchmate as `taken`, which means the batchmate has taken the module(s) before.
 
 Format: `mod mark INDEX MODULE [MORE_MODULES]...`
 
@@ -185,7 +185,7 @@ Examples:
 
 ### Unmarking module as not taken: `mod unmark`
 
-Unmarks module(s) of a batchmate as not taken, which means the batchmate has not taken and is not currently taking the module(s).
+Unmarks module(s) of a batchmate as not taken, which means the batchmate is currently taking the module(s).
 
 Format: `mod unmark INDEX MODULE [MORE_MODULES]...`
 

--- a/src/main/java/seedu/address/logic/commands/ModUnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModUnmarkCommand.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Mod;
+import seedu.address.model.person.Person;
+
+/**
+ * Unmarks mods of the batchmate specified as not taken.
+ */
+public class ModUnmarkCommand extends ModCommand {
+
+    public static final String COMMAND_WORD = "unmark";
+    public static final String MESSAGE_SUCCESS = "Successfully unmarked the specified mods.";
+    public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified."
+            + "\nPlease check the list of mods and try again.";
+    private final Index targetIndex;
+    private final ObservableList<Mod> mods;
+
+    /**
+     * Constructs a command that unmarks all mods specified at the target batchmate as not taken.
+     *
+     * @param index The index of the batchmate.
+     * @param mods The set of mods to be unmarked.
+     */
+    public ModUnmarkCommand(Index index, ObservableList<Mod> mods) {
+        requireNonNull(index);
+        requireNonNull(mods);
+
+        this.targetIndex = index;
+        this.mods = mods;
+    }
+
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
+
+        if (personToEdit.canEditMods(mods)) {
+            personToEdit.unmarkMods(mods);
+        } else {
+            throw new CommandException(MESSAGE_INVALID_MOD);
+        }
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, personToEdit),
+                false,
+                false,
+                false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ModUnmarkCommand)) {
+            return false;
+        }
+
+        // state check
+        ModUnmarkCommand e = (ModUnmarkCommand) other;
+        return targetIndex.equals(e.targetIndex)
+                && mods.equals(e.mods);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModCommandParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.ModAddCommand;
 import seedu.address.logic.commands.ModCommand;
 import seedu.address.logic.commands.ModDeleteCommand;
 import seedu.address.logic.commands.ModMarkCommand;
+import seedu.address.logic.commands.ModUnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Mod;
 
@@ -62,11 +63,20 @@ public class ModCommandParser implements Parser<ModCommand> {
             return parseDeleteCommand(arguments);
         case ModMarkCommand.COMMAND_WORD:
             return parseMarkCommand(arguments);
+        case ModUnmarkCommand.COMMAND_WORD:
+            return parseUnmarkCommand(arguments);
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModCommand.MESSAGE_USAGE));
         }
     }
 
+    /**
+     * Parses a mod add command from user to construct a ModAddCommand for execution.
+     *
+     * @param args Arguments from user input.
+     * @return A ModAddCommand for execution.
+     * @throws ParseException If there is a parse error.
+     */
     private ModAddCommand parseAddCommand(String args) throws ParseException {
         Index index;
         String trimmedArgs = args.trim();
@@ -85,6 +95,13 @@ public class ModCommandParser implements Parser<ModCommand> {
         return new ModAddCommand(index, mods.get());
     }
 
+    /**
+     * Parses a mod delete command from user to construct a ModDeleteCommand for execution.
+     *
+     * @param args Arguments from user input.
+     * @return A ModDeleteCommand for execution.
+     * @throws ParseException If there is a parse error.
+     */
     private ModDeleteCommand parseDeleteCommand(String args) throws ParseException {
         Index index;
         String trimmedArgs = args.trim();
@@ -103,6 +120,13 @@ public class ModCommandParser implements Parser<ModCommand> {
         return new ModDeleteCommand(index, mods.get());
     }
 
+    /**
+     * Parses a mod mark command from user to construct a ModMarkCommand for execution.
+     *
+     * @param args Arguments from user input.
+     * @return A ModMarkCommand for execution.
+     * @throws ParseException If there is a parse error.
+     */
     private ModMarkCommand parseMarkCommand(String args) throws ParseException {
         Index index;
         String trimmedArgs = args.trim();
@@ -119,6 +143,31 @@ public class ModCommandParser implements Parser<ModCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE), pe);
         }
         return new ModMarkCommand(index, mods.get());
+    }
+
+    /**
+     * Parses a mod unmark command from user to construct a ModUnmarkCommand for execution.
+     *
+     * @param args Arguments from user input.
+     * @return A ModUnmarkCommand for execution.
+     * @throws ParseException If there is a parse error.
+     */
+    private ModUnmarkCommand parseUnmarkCommand(String args) throws ParseException {
+        Index index;
+        String trimmedArgs = args.trim();
+        String indexFromCommand = getIndexFromCommand(trimmedArgs);
+        Set<String> modsFromCommand = getModsFromCommand(trimmedArgs);
+        Optional<ObservableList<Mod>> mods = parseMods(modsFromCommand);
+        if (mods.isEmpty()) {
+            throw new ParseException(ModCommand.MESSAGE_MODS_EMPTY);
+        }
+
+        try {
+            index = ParserUtil.parseIndex(indexFromCommand);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE), pe);
+        }
+        return new ModUnmarkCommand(index, mods.get());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -135,6 +135,27 @@ public class Person {
     }
 
     /**
+     * Unmarks all mods in {@code mods} in the current set of mods linked to this batchmate as not taken.
+     *
+     * @param mods The set of mods to be unmarked.
+     */
+    public void unmarkMods(ObservableList<Mod> mods) {
+        for (int i = 0; i < mods.size(); i++) {
+            for (int j = 0; j < this.mods.size(); j++) {
+
+                Mod currentMod = this.mods.get(j);
+                String currentModName = currentMod.modName;
+                String targetModName = mods.get(i).modName;
+
+                if (currentModName.equals(targetModName)) {
+                    currentMod.unmarkMod();
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */

--- a/src/test/java/seedu/address/logic/commands/ModUnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModUnmarkCommandTest.java
@@ -1,0 +1,197 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Mod;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Test class for ModUnmarkCommand.
+ */
+public class ModUnmarkCommandTest {
+
+    private static final Mod VALID_MOD_CS2100 = new Mod("CS2100", true);
+    private static final Mod VALID_MOD_CS2101 = new Mod("CS2101", true);
+    private static final Mod VALID_MOD_CS2103 = new Mod("CS2103", true);
+    private static final Mod MOD_NOT_FOUND_CS2105 = new Mod("CS2105", true);
+    private static Model model;
+
+    /**
+     * Sets up the model before each test.
+     */
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when index is not entered.
+     */
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ModUnmarkCommand(null, FXCollections.observableArrayList()));
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when mod is not entered.
+     */
+    @Test
+    public void constructor_nullMods_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ModUnmarkCommand(INDEX_FIRST_PERSON, null));
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when the student wants to unmark 1 existing mod
+     * in the list of taken modules of a batchmate.
+     *
+     * @throws CommandException If an error which occurs during execution of ModUnmarkCommand.
+     */
+    @Test
+    public void execute_unmarkOneMod_success() throws CommandException {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(VALID_MOD_CS2100.modName).build();
+        model.addPerson(batchmate);
+
+        batchmate.getMods().get(0).markMod();
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        ModUnmarkCommand commandToExecute = new ModUnmarkCommand(indexLastPerson,
+                FXCollections.singletonObservableList(VALID_MOD_CS2100));
+        CommandResult commandResult = commandToExecute.execute(model);
+
+        String actualModStatus = batchmate.getMods().get(0).toString();
+        String expectedModStatus = "[CS2100: false]";
+
+        assertEquals(expectedModStatus, actualModStatus);
+        assertEquals(ModUnmarkCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when the student wants to unmark 2 existing mods
+     * in the list of taken modules of a batchmate.
+     *
+     * @throws CommandException If an error which occurs during execution of ModUnmarkCommand.
+     */
+    @Test
+    public void execute_unmarkMultipleMod_success() throws CommandException {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                        VALID_MOD_CS2100.modName,
+                        VALID_MOD_CS2103.modName,
+                        VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        batchmate.getMods().get(0).markMod();
+        batchmate.getMods().get(1).markMod();
+        batchmate.getMods().get(2).markMod();
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        ModUnmarkCommand commandToExecute = new ModUnmarkCommand(indexLastPerson,
+                FXCollections.observableArrayList(VALID_MOD_CS2101, VALID_MOD_CS2100));
+        CommandResult commandResult = commandToExecute.execute(model);
+
+        String actualFirstModStatus = batchmate.getMods().get(0).toString();
+        String actualSecondModStatus = batchmate.getMods().get(1).toString();
+        String actualThirdModStatus = batchmate.getMods().get(2).toString();
+        String actualModStatus = actualFirstModStatus + actualSecondModStatus + actualThirdModStatus;
+
+        String expectedModStatus = "[CS2100: false]" + "[CS2103: true]" + "[CS2101: false]";
+
+        assertEquals(expectedModStatus, actualModStatus);
+        assertEquals(ModUnmarkCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when the student wants to unmark 1 non-existing mod
+     * in the list of taken modules of a batchmate.
+     */
+    @Test
+    public void execute_unmarkNonExistingMod1_throwsCommandException() {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                        VALID_MOD_CS2100.modName,
+                        VALID_MOD_CS2103.modName,
+                        VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        batchmate.getMods().get(0).markMod();
+        batchmate.getMods().get(1).markMod();
+        batchmate.getMods().get(2).markMod();
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        try {
+            ModUnmarkCommand commandToExecute = new ModUnmarkCommand(indexLastPerson,
+                    FXCollections.observableArrayList(MOD_NOT_FOUND_CS2105));
+            commandToExecute.execute(model);
+            fail(); // Test should not reach this line.
+        } catch (CommandException e) {
+            assertEquals(ModUnmarkCommand.MESSAGE_INVALID_MOD, e.getMessage());
+        }
+
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when the student wants to unmark multiple mods containing
+     * 1 non-existing mod in the list of taken modules of a batchmate.
+     */
+    @Test
+    public void execute_unmarkNonExistingMod2_throwsCommandException() {
+
+        Person batchmate = new PersonBuilder(BOB).withMods(
+                        VALID_MOD_CS2100.modName,
+                        VALID_MOD_CS2103.modName,
+                        VALID_MOD_CS2101.modName)
+                .build();
+        model.addPerson(batchmate);
+
+        batchmate.getMods().get(0).markMod();
+        batchmate.getMods().get(1).markMod();
+        batchmate.getMods().get(2).markMod();
+
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        try {
+            ModUnmarkCommand commandToExecute = new ModUnmarkCommand(indexLastPerson,
+                    FXCollections.observableArrayList(VALID_MOD_CS2101, VALID_MOD_CS2103, MOD_NOT_FOUND_CS2105));
+            commandToExecute.execute(model);
+            fail(); // Test should not reach this line.
+        } catch (CommandException e) {
+            assertEquals(ModUnmarkCommand.MESSAGE_INVALID_MOD, e.getMessage());
+        }
+
+    }
+
+    /**
+     * Tests the behaviour of ModUnmarkCommand when index is out of range.
+     *
+     * @throws CommandException If an error which occurs during execution of ModUnmarkCommand.
+     */
+    @Test
+    public void execute_indexOutOfBounds_throwsCommandException() throws CommandException {
+        Index indexOutOfBounds = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ModUnmarkCommand invalidCommand = new ModUnmarkCommand(indexOutOfBounds,
+                FXCollections.singletonObservableList(VALID_MOD_CS2100));
+        assertCommandFailure(invalidCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModCommandParserTest.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.ModAddCommand;
 import seedu.address.logic.commands.ModCommand;
 import seedu.address.logic.commands.ModDeleteCommand;
 import seedu.address.logic.commands.ModMarkCommand;
+import seedu.address.logic.commands.ModUnmarkCommand;
 import seedu.address.model.person.Mod;
 
 public class ModCommandParserTest {
@@ -24,12 +25,18 @@ public class ModCommandParserTest {
     private static final String VALID_MOD_STRING_CS2100 = "CS2100";
     private final ModCommandParser parser = new ModCommandParser();
 
+    /**
+     * Tests the behaviour of mod commands when there is an empty command input by user.
+     */
     @Test
     public void parse_emptyArg_throwParseException() {
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 ModCommand.MESSAGE_USAGE));
     }
 
+    /**
+     * Tests the behaviour of mod commands when there is an unknown command input by user.
+     */
     @Test
     public void parse_unknownCommand_throwParseException() {
         assertParseFailure(parser,
@@ -38,31 +45,48 @@ public class ModCommandParserTest {
                 ModCommand.MESSAGE_USAGE));
     }
 
+    /**
+     * Tests the behaviour of mod add when index is absent.
+     */
     @Test
     public void parse_noIndex_throwParseException() {
         assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
                 ModCommand.MESSAGE_INDEX_EMPTY);
     }
 
+    /**
+     * Tests the behaviour of mod add when mod is absent.
+     */
     @Test
     public void parse_noMods_throwParseException() {
         assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
                 ModCommand.MESSAGE_MODS_EMPTY);
     }
 
+    /**
+     * Tests the behaviour of mod add when mod is invalid.
+     */
     @Test
     public void parse_invalidMod_throwParseException() {
         assertParseFailure(parser,
-                ModAddCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + INVALID_MOD_STRING,
+                ModAddCommand.COMMAND_WORD
+                        + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " " + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
+    /**
+     * Tests the behaviour of mod add when index is invalid.
+     */
     @Test
     public void parse_invalidIndex_throwParseException() {
         assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
     }
 
+    /**
+     * Tests the behaviour of adding 1 mod.
+     */
     @Test
     public void parse_oneMod_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
@@ -75,6 +99,9 @@ public class ModCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
+    /**
+     * Tests the behaviour of adding multiple mods.
+     */
     @Test
     public void parse_manyMods_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
@@ -116,7 +143,9 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidModModDelete_throwParseException() {
         assertParseFailure(parser,
-                ModDeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + INVALID_MOD_STRING,
+                ModDeleteCommand.COMMAND_WORD
+                        + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " " + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -126,7 +155,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndexModDelete_throwParseException() {
         assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModDeleteCommand.MESSAGE_USAGE));
     }
 
     /**
@@ -188,7 +217,9 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidModModMark_throwParseException() {
         assertParseFailure(parser,
-                ModMarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + INVALID_MOD_STRING,
+                ModMarkCommand.COMMAND_WORD
+                        + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " " + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -198,7 +229,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndexModMark_throwParseException() {
         assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE));
     }
 
     /**
@@ -232,6 +263,80 @@ public class ModCommandParserTest {
         mods.add(new Mod(VALID_MOD_STRING_CS2103T));
         mods.add(new Mod(VALID_MOD_STRING_CS2101));
         ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of mod unmark when index is absent.
+     */
+    @Test
+    public void parse_noIndexModUnmark_throwParseException() {
+        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+                ModCommand.MESSAGE_INDEX_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod unmark when mod is absent.
+     */
+    @Test
+    public void parse_noModsModUnmark_throwParseException() {
+        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
+                ModCommand.MESSAGE_MODS_EMPTY);
+    }
+
+    /**
+     * Tests the behaviour of mod unmark when mod is invalid.
+     */
+    @Test
+    public void parse_invalidModModUnmark_throwParseException() {
+        assertParseFailure(parser,
+                ModUnmarkCommand.COMMAND_WORD
+                        + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " " + INVALID_MOD_STRING,
+                Mod.MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Tests the behaviour of mod unmark when index is invalid.
+     */
+    @Test
+    public void parse_invalidIndexModUnmark_throwParseException() {
+        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModUnmarkCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the behaviour of unmarking 1 mod as not taken.
+     */
+    @Test
+    public void parse_unmarkOneMod_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModUnmarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T;
+
+        ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
+        ModUnmarkCommand expectedCommand = new ModUnmarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of unmarking multiple mods as not taken.
+     */
+    @Test
+    public void parse_unmarkMultipleMods_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = ModUnmarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
+                + " " + VALID_MOD_STRING_CS2103T
+                + " " + VALID_MOD_STRING_CS2101
+                + " " + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModUnmarkCommand expectedCommand = new ModUnmarkCommand(targetIndex, mods);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
Student is unable to unmark a taken mod as not taken for a batchmate, so any accidental marking of mod previously could not be undone.

Adding a mod unmark function could allow student to change and update the status of mods of a batchmate more easily.

Let's
* implement the mod unmark command
* add tests for mod unmark command
* update UG for mod mark and mod unmark to change some phrasing

Fixes #88 .