### PR TITLE
Modify Mod Categorisation to abide by SRP

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -17,6 +17,7 @@ import seedu.address.model.interest.Interest;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.GitHub;
 import seedu.address.model.person.Mod;
+import seedu.address.model.person.Mod.ModCategory;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
@@ -162,5 +163,37 @@ public class ParserUtil {
             modSet.add(parseMod(modName));
         }
         return modSet;
+    }
+
+    /**
+     * Parses {@code String modName} into a {@code ModCategory}
+     *
+     * @param modName The module name.
+     * @return The category that the module name fall under.
+     */
+    public static ModCategory parseModsToCategory(String modName) {
+        assert modName != null;
+
+        String modPrefix = modName.split("[0-9]")[0].substring(0, 2);
+        switch (modPrefix) {
+        case "CS":
+        case "IS":
+        case "CP":
+            return ModCategory.COMP;
+        case "MA":
+        case "ST":
+            return ModCategory.MATH;
+        case "LS":
+        case "CM":
+        case "PC":
+            return ModCategory.SCI;
+        case "ES":
+            return ModCategory.COMMS;
+        case "GE":
+        case "UT":
+            return ModCategory.GE;
+        default:
+            return ModCategory.UE;
+        }
     }
 }

--- a/src/main/java/seedu/address/model/person/Mod.java
+++ b/src/main/java/seedu/address/model/person/Mod.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.logic.parser.ParserUtil;
+
 /**
  * Represents a mod in Mass Linkers.
  * Guarantees: immutable; name is valid as declared in {@link #isValidModName(String)}
@@ -26,7 +28,7 @@ public class Mod {
         checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
         this.modName = modName.toUpperCase();
         this.hasTaken = false;
-        this.modCategory = getModCategory(modName);
+        this.modCategory = ParserUtil.parseModsToCategory(modName);
     }
 
     /**
@@ -40,7 +42,7 @@ public class Mod {
         checkArgument(isValidModName(modName), MESSAGE_CONSTRAINTS);
         this.modName = modName.toUpperCase();
         this.hasTaken = hasTaken;
-        this.modCategory = getModCategory(modName);
+        this.modCategory = ParserUtil.parseModsToCategory(modName);
     }
 
     /**
@@ -102,38 +104,6 @@ public class Mod {
      */
     public ModCategory getModCategory() {
         return this.modCategory;
-    }
-
-    /**
-     * Gets mod category from the given mod name.
-     *
-     * @param modName The mod name.
-     * @return The mod category.
-     */
-    private ModCategory getModCategory(String modName) {
-        assert modName != null;
-
-        String modPrefix = modName.split("[0-9]")[0].substring(0, 2);
-        switch (modPrefix) {
-        case "CS":
-        case "IS":
-        case "CP":
-            return ModCategory.COMP;
-        case "MA":
-        case "ST":
-            return ModCategory.MATH;
-        case "LS":
-        case "CM":
-        case "PC":
-            return ModCategory.SCI;
-        case "ES":
-            return ModCategory.COMMS;
-        case "GE":
-        case "UT":
-            return ModCategory.GE;
-        default:
-            return ModCategory.UE;
-        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -271,4 +271,37 @@ public class ParserUtilTest {
 
         assertEquals(expectedModSet, actualModSet);
     }
+
+    /**
+     * Tests the behaviour of the {@code parseModsToCategory} method
+     */
+    @Test
+    public void parseMods_correctAssigmentOfCategory() {
+        // CS Mods
+        assertEquals(Mod.ModCategory.COMP, ParserUtil.parseModsToCategory("CS2100"));
+        assertEquals(Mod.ModCategory.COMP, ParserUtil.parseModsToCategory("CS2103T"));
+        assertEquals(Mod.ModCategory.COMP, ParserUtil.parseModsToCategory("CP2106"));
+        assertEquals(Mod.ModCategory.COMP, ParserUtil.parseModsToCategory("IS1108"));
+
+        // Math Mods
+        assertEquals(Mod.ModCategory.MATH, ParserUtil.parseModsToCategory("ST2334"));
+        assertEquals(Mod.ModCategory.MATH, ParserUtil.parseModsToCategory("MA1521"));
+        assertEquals(Mod.ModCategory.MATH, ParserUtil.parseModsToCategory("MA2001"));
+
+        // Sci Mods
+        assertEquals(Mod.ModCategory.SCI, ParserUtil.parseModsToCategory("LSM1301"));
+        assertEquals(Mod.ModCategory.SCI, ParserUtil.parseModsToCategory("CM1102"));
+        assertEquals(Mod.ModCategory.SCI, ParserUtil.parseModsToCategory("PC1202"));
+
+        // GE Mods
+        assertEquals(Mod.ModCategory.GE, ParserUtil.parseModsToCategory("GEA1000"));
+        assertEquals(Mod.ModCategory.GE, ParserUtil.parseModsToCategory("UTC1102B"));
+        assertEquals(Mod.ModCategory.GE, ParserUtil.parseModsToCategory("GESS1025"));
+
+        // COMMS Mods
+        assertEquals(Mod.ModCategory.COMMS, ParserUtil.parseModsToCategory("ES2660"));
+
+        // UE Mods
+        assertEquals(Mod.ModCategory.UE, ParserUtil.parseModsToCategory("CFG1002"));
+    }
 }


### PR DESCRIPTION
The `Mod` class did not abide by SRP as it was responsible for both module attributes and parsing module names into a module category.

Let's
* Move the mod categorisation into `ParserUtil`.
* Add tests for mod categorisation in `ParserUtil`.

Fix from #98
**The changes should not affect the UI for mod categorisation**
