### PR TITLE
Sort mods by completion and name

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,7 +10,9 @@ import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.model.interest.Interest;
+import seedu.address.model.util.ModComparator;
 
 /**
  * Represents a Person in the address book.
@@ -88,11 +90,11 @@ public class Person {
     }
 
     /**
-     * Returns an immutable mods list, which throws {@code UnsupportedOperationException}
+     * Sorts then returns an immutable mods list, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public ObservableList<Mod> getMods() {
-        return FXCollections.unmodifiableObservableList(mods);
+        return FXCollections.unmodifiableObservableList(new SortedList<>(mods, new ModComparator()));
     }
 
     /**
@@ -208,7 +210,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, handle, gitHub, interests, mods);
+        return Objects.hash(name, phone, email, handle, gitHub, interests, getMods());
     }
 
     @Override
@@ -225,13 +227,14 @@ public class Person {
                 .append(getEmail());
 
         Set<Interest> interestSet = getInterests();
+        ObservableList<Mod> sortedMods = getMods();
         if (!interestSet.isEmpty()) {
             builder.append("; Interests: ");
             interestSet.forEach(builder::append);
         }
-        if (!mods.isEmpty()) {
+        if (!sortedMods.isEmpty()) {
             builder.append("; Mods: ");
-            mods.forEach(builder::append);
+            sortedMods.forEach(builder::append);
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/util/ModComparator.java
+++ b/src/main/java/seedu/address/model/util/ModComparator.java
@@ -1,0 +1,42 @@
+package seedu.address.model.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+
+import seedu.address.model.person.Mod;
+
+/**
+ * Comparator to compare order for mods.
+ */
+public class ModComparator implements Comparator<Mod> {
+    /**
+     * Compares a mod with another for order. Returns a
+     * negative integer, zero, or a positive integer if a mod is less
+     * than, equal to, or greater than the other.
+     *
+     * @param mod1 the object to be compared.
+     * @param mod2 the object to be compared.
+     * @return a negative integer, zero, or a positive integer if a mod
+     *         is less than, equal to, or greater than the other.
+     */
+
+    public int compare(Mod mod1, Mod mod2) {
+        requireNonNull(mod1);
+        requireNonNull(mod2);
+
+        if (mod1.getModStatus()) {
+            if (mod2.getModStatus()) {
+                return mod1.getModName().compareTo(mod2.getModName());
+            } else {
+                return 1;
+            }
+        } else {
+            if (mod2.getModStatus()) {
+                return -1;
+            } else {
+                return mod1.getModName().compareTo(mod2.getModName());
+            }
+        }
+    }
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,10 +7,10 @@
     "handle" : "alice",
     "username" : "alifur",
     "mods" : [ {
-      "modName" : "CS2100",
+      "modName" : "CS1231S",
       "hasTaken" : false
     }, {
-      "modName" : "CS1231S",
+      "modName" : "CS2100",
       "hasTaken" : true
     } ],
     "interests" : [ "tennis" ]
@@ -57,10 +57,10 @@
     "handle" : "ellie",
     "username" : "goldl8ol",
     "mods" : [ {
-      "modName" : "CS2100",
+      "modName" : "CS1231S",
       "hasTaken" : false
     }, {
-      "modName" : "CS1231S",
+      "modName" : "CS2100",
       "hasTaken" : false
     } ],
     "interests" : [ ]

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -53,7 +53,6 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
-        //System.out.println(expectedMessage);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);

--- a/src/test/java/seedu/address/logic/commands/ModMarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModMarkCommandTest.java
@@ -107,7 +107,7 @@ public class ModMarkCommandTest {
         String actualThirdModStatus = batchmate.getMods().get(2).toString();
         String actualModStatus = actualFirstModStatus + actualSecondModStatus + actualThirdModStatus;
 
-        String expectedModStatus = "[CS2100: true]" + "[CS2103: false]" + "[CS2101: true]";
+        String expectedModStatus = "[CS2103: false]" + "[CS2100: true]" + "[CS2101: true]";
 
         assertEquals(expectedModStatus, actualModStatus);
         assertEquals(ModMarkCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/logic/commands/ModUnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModUnmarkCommandTest.java
@@ -113,7 +113,7 @@ public class ModUnmarkCommandTest {
         String actualThirdModStatus = batchmate.getMods().get(2).toString();
         String actualModStatus = actualFirstModStatus + actualSecondModStatus + actualThirdModStatus;
 
-        String expectedModStatus = "[CS2100: false]" + "[CS2103: true]" + "[CS2101: false]";
+        String expectedModStatus = "[CS2100: false]" + "[CS2101: false]" + "[CS2103: true]";
 
         assertEquals(expectedModStatus, actualModStatus);
         assertEquals(ModUnmarkCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/model/util/ModComparatorTest.java
+++ b/src/test/java/seedu/address/model/util/ModComparatorTest.java
@@ -11,29 +11,44 @@ public class ModComparatorTest {
 
     private final ModComparator comparator = new ModComparator();
 
+    /**
+     * Tests the behaviour when both inputs are null.
+     */
     @Test
     public void compare_compareBothNull() {
         assertThrows(NullPointerException.class, () -> comparator.compare(null, null));
     }
 
+    /**
+     * Tests the behaviour when one input is null.
+     */
     @Test
     public void compare_compareOneNull() {
         assertThrows(NullPointerException.class, () -> comparator.compare(new Mod("CS2103T"), null));
         assertThrows(NullPointerException.class, () -> comparator.compare(null, new Mod("CS2103T")));
     }
 
+    /**
+     * Tests the behaviour when the 2 mods differ in completion status.
+     */
     @Test
     public void compare_completionStatus() {
         assertTrue(comparator.compare(new Mod("CS2103T", true), new Mod("CS2103T")) > 0);
         assertTrue(comparator.compare(new Mod("CS2103T"), new Mod("CS2103T", true)) < 0);
     }
 
+    /**
+     * Tests the behaviour when the 2 mods differ in their mod name.
+     */
     @Test
     public void compare_modName() {
         assertTrue(comparator.compare(new Mod("DS2103T"), new Mod("CS2103T")) > 0);
         assertTrue(comparator.compare(new Mod("AS2103T"), new Mod("CS2103T")) < 0);
     }
 
+    /**
+     * Tests the behaviour when the 2 mods differ in completion status and mod name.
+     */
     @Test
     public void compare_modNameAndCompletion() {
         assertTrue(comparator.compare(new Mod("DS2103T", true), new Mod("CS2103T", false)) > 0);

--- a/src/test/java/seedu/address/model/util/ModComparatorTest.java
+++ b/src/test/java/seedu/address/model/util/ModComparatorTest.java
@@ -1,0 +1,44 @@
+package seedu.address.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Mod;
+
+public class ModComparatorTest {
+
+    private final ModComparator comparator = new ModComparator();
+
+    @Test
+    public void compare_compareBothNull() {
+        assertThrows(NullPointerException.class, () -> comparator.compare(null, null));
+    }
+
+    @Test
+    public void compare_compareOneNull() {
+        assertThrows(NullPointerException.class, () -> comparator.compare(new Mod("CS2103T"), null));
+        assertThrows(NullPointerException.class, () -> comparator.compare(null, new Mod("CS2103T")));
+    }
+
+    @Test
+    public void compare_completionStatus() {
+        assertTrue(comparator.compare(new Mod("CS2103T", true), new Mod("CS2103T")) > 0);
+        assertTrue(comparator.compare(new Mod("CS2103T"), new Mod("CS2103T", true)) < 0);
+    }
+
+    @Test
+    public void compare_modName() {
+        assertTrue(comparator.compare(new Mod("DS2103T"), new Mod("CS2103T")) > 0);
+        assertTrue(comparator.compare(new Mod("AS2103T"), new Mod("CS2103T")) < 0);
+    }
+
+    @Test
+    public void compare_modNameAndCompletion() {
+        assertTrue(comparator.compare(new Mod("DS2103T", true), new Mod("CS2103T", false)) > 0);
+        assertTrue(comparator.compare(new Mod("CS2103T", true), new Mod("DS2103T", false)) > 0);
+        assertTrue(comparator.compare(new Mod("DS2103T", false), new Mod("CS2103T", true)) < 0);
+        assertTrue(comparator.compare(new Mod("CS2103T", false), new Mod("DS2103T", true)) < 0);
+    }
+}


### PR DESCRIPTION
Sorts mods by their completion (taking in front) and then by their `modName` in lexicographic order.

* Add a new `ModComparator` class to compare 2 mods
* Change `Person` to return a `SortedList`
* Add tests for `ModComparator`
* Change default data to abide by the new order

Note: All default data in test/data have to follow the new order or many test cases will fail.