### PR TITLE
Change mod mark all command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,13 +215,9 @@ Examples:
 
 ### Marking module of all as taken: `mod mark all`
 
-Marks module(s) of all batchmates as taken. This is useful for updating the module status of all batchmates after each semester.
+Marks all modules of all batchmates as taken. This is useful for updating the module status of all modules of all batchmates after each semester.
 
-Format: `mod mark all MODULE [MORE_MODULES]...`
-
-Examples:
-* `mod mark all cs2103t` marks the module `cs2103t` of all batchmates as taken.
-* `mod mark all cs2100 cs2103t cs2101 cs2105` marks the modules `cs2100`, `cs2103t`, `cs2101` and `cs2105` of all batchmates as taken.
+Format: `mod mark all`
 
 ### Find modules: `mod find`
 
@@ -307,7 +303,7 @@ Module prefix refers to the first two characters of every module name.
 | **Delete module**                | `mod delete INDEX MODULE [MORE_MODULES]...` <br> Example: `mod delete 3 cs2100 cs2103t cs2101 cs2105`                                                                                                        |
 | **Mark module**                  | `mod mark INDEX MODULE [MORE_MODULES]...` <br> Example: `mod mark 3 cs2100 cs2103t cs2101 cs2105`                                                                                                            |
 | **Unmark module**                | `mod unmark INDEX MODULE [MORE_MODULES]...` <br> Example: `mod unmark 3 cs2100 cs2103t cs2101 cs2105`                                                                                                        |
-| **Mark module of all**           | `mod mark all MODULE [MORE_MODULES]...` <br> Example: `mod mark all cs2100 cs2103t cs2101 cs2105`                                                                                                            |
+| **Mark module of all**           | `mod mark all`                                                                                                                                                                                               |
 | **Find module**                  | `mod find MODULE [MORE_MODULES]...` <br> Example: `mod find cs2101 cs2103t`                                                                                                                                  |
 | **Find modules taken or taking** | `mod find taken MODULE [MORE_MODULES]...` <br> `mod find taking MODULE [MORE_MODULES]...` <br> Example: `mod find taken cs2100` or <br> `mod find taking cs2101 cs2103t`                                     |
 | **Exit**                         | `exit`                                                                                                                                                                                                       |

--- a/src/main/java/seedu/address/logic/commands/ModMarkAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModMarkAllCommand.java
@@ -4,35 +4,22 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Mod;
 import seedu.address.model.person.Person;
 
 /**
- * Marks mods of all batchmates as taken.
+ * Marks all mods of all batchmates as taken.
  */
 public class ModMarkAllCommand extends ModCommand {
 
     public static final String COMMAND_WORD = "mark all";
-    public static final String MESSAGE_SUCCESS = "Successfully marked %s of all batchmates.\n";
-    public static final String MESSAGE_INVALID_MOD = "There is no batchmate taking %s, hence it's not marked.\n";
-    public static final String MESSAGE_INVALID_MODS = "All mods specified are not being taken by any batchmate.\n"
-            + "Please check the list of mods and try again.";
-
-    private final ObservableList<Mod> mods;
+    public static final String MESSAGE_SUCCESS = "Successfully marked all mods of all batchmates as taken.\n";
 
     /**
-     * Constructs a command that marks all mods specified of all batchmates as taken.
-     *
-     * @param mods The set of mods to be marked.
+     * Constructs a command that marks all mods of all batchmates as taken.
      */
-    public ModMarkAllCommand(ObservableList<Mod> mods) {
-        requireNonNull(mods);
-
-        this.mods = mods;
-    }
+    public ModMarkAllCommand() {}
 
     /**
      * Executes the command and returns the result message.
@@ -46,48 +33,13 @@ public class ModMarkAllCommand extends ModCommand {
         requireNonNull(model);
 
         List<Person> lastShownList = model.getFilteredPersonList();
-        String message = "";
-        int markedModsCount = 0;
 
-        for (Mod mod : mods) {
-            int markedModCount = 0;
-            for (Person person : lastShownList) {
-                markedModCount = markedModCount + person.markModIfExist(mod);
-            }
-
-            if (markedModCount == 0) {
-                // No batchmate is taking the specified mod.
-                message = message + String.format(MESSAGE_INVALID_MOD, mod.getModName());
-            } else {
-                message = message + String.format(MESSAGE_SUCCESS, mod.getModName());
-            }
-
-            markedModsCount = markedModsCount + markedModCount;
-        }
-
-        if (markedModsCount == 0) {
-            // No mod in mods has been successfully marked.
-            throw new CommandException(MESSAGE_INVALID_MODS);
+        for (Person person : lastShownList) {
+            person.markAllMods();
         }
 
         return new CommandResult(
-                message, false, false, false, false);
+                MESSAGE_SUCCESS, false, false, false, false);
     }
 
-    @Override
-    public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof ModMarkAllCommand)) {
-            return false;
-        }
-
-        // state check
-        ModMarkAllCommand e = (ModMarkAllCommand) other;
-        return mods.equals(e.mods);
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModCommandParser.java
@@ -144,11 +144,11 @@ public class ModCommandParser implements Parser<ModCommand> {
         Set<String> modsFromCommand = getModsFromCommand(trimmedArgs);
         Optional<ObservableList<Mod>> mods = parseMods(modsFromCommand);
 
-        if (mods.isEmpty()) {
-            throw new ParseException(ModCommand.MESSAGE_MODS_EMPTY);
+        if (indexOrAll.equals("all")) {
+            return new ModMarkAllCommand();
 
-        } else if (indexOrAll.equals("all")) {
-            return new ModMarkAllCommand(mods.get());
+        } else if (mods.isEmpty()) {
+            throw new ParseException(ModCommand.MESSAGE_MODS_EMPTY);
 
         } else {
             try {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -152,27 +152,12 @@ public class Person {
     }
 
     /**
-     * Marks the specified mod as taken if it exists in the current list of mods linked to this batchmate.
-     *
-     * @param mod The mod to be marked.
-     * @return 1 if the specified mod exists and is marked, or 0 if the mod is not in the list of mods.
+     * Marks all mods of a batchmate as taken.
      */
-    public int markModIfExist(Mod mod) {
-        int count = 0;
-
-        for (int j = 0; j < this.mods.size(); j++) {
-
-            Mod currentMod = this.mods.get(j);
-            String currentModName = currentMod.getModName();
-            String targetModName = mod.getModName();
-
-            if (currentModName.equals(targetModName)) {
-                currentMod.markMod();
-                count++;
-                break;
-            }
+    public void markAllMods() {
+        for (Mod mod : this.mods) {
+            mod.markMod();
         }
-        return count;
     }
 
     /**


### PR DESCRIPTION
A student could only mark specified mods of all batchmates, which may be inconvenient when student wants to update all mod status of all batchmates at the end of each semester.

Allowing the student to mark all mods of all batchmates with a single command would be more convenient to update mod status.

Let's change the mod mark all command from
`mod mark all MODULE [MORE_MODULES]...` to `mod mark all`.