### PR TITLE
Fix bug in addInt and findInt 

### DIFF
--- a/src/main/java/seedu/masslinkers/commons/core/Messages.java
+++ b/src/main/java/seedu/masslinkers/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_INVALID_INTERESTS = "Interests should be alphanumeric";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
 
 }

--- a/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.masslinkers.logic.parser;
 
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_INTERESTS;
 import static seedu.masslinkers.logic.parser.ParserUtil.parseIndex;
 
 import java.util.Arrays;
@@ -39,7 +40,14 @@ public class AddInterestCommandParser implements Parser<AddInterestCommand> {
         }
 
         String indexFromCommand = getIndexFromCommand(trimmedArgs);
-        Set<Interest> interestList = getInterestsFromCommand(trimmedArgs);
+        Set<Interest> interestSet;
+
+        try {
+            interestSet = getInterestsFromCommand(trimmedArgs);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_INTERESTS,
+                    AddInterestCommand.MESSAGE_USAGE), e);
+        }
 
         try {
             index = parseIndex(indexFromCommand);
@@ -48,11 +56,11 @@ public class AddInterestCommandParser implements Parser<AddInterestCommand> {
                     AddInterestCommand.MESSAGE_USAGE), pe);
         }
 
-        if (interestList.isEmpty()) {
+        if (interestSet.isEmpty()) {
             throw new ParseException(MESSAGE_INTERESTS_EMPTY);
         }
 
-        return new AddInterestCommand(index, interestList);
+        return new AddInterestCommand(index, interestSet);
     }
 
     /**

--- a/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.masslinkers.logic.parser;
 
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_INTERESTS;
 import static seedu.masslinkers.logic.parser.ParserUtil.parseIndex;
 
 import java.util.Arrays;
@@ -38,7 +39,14 @@ public class DeleteInterestCommandParser implements Parser<DeleteInterestCommand
         }
 
         String indexFromCommand = getIndexFromCommand(trimmedArgs);
-        Set<Interest> interestSet = getInterestsFromCommand(trimmedArgs);
+        Set<Interest> interestSet;
+
+        try {
+            interestSet = getInterestsFromCommand(trimmedArgs);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_INTERESTS,
+                    DeleteInterestCommand.MESSAGE_USAGE), e);
+        }
 
         try {
             index = parseIndex(indexFromCommand);


### PR DESCRIPTION
Adding or finding non-alphanumeric interests will result in an uncaught exception.
So a catch block is added in both the addInt and findInt parser classes.