### PR TITLE
Fix error message and display bugs

### DIFF
--- a/src/main/java/seedu/masslinkers/commons/core/Messages.java
+++ b/src/main/java/seedu/masslinkers/commons/core/Messages.java
@@ -9,8 +9,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INCOMPLETE_COMMAND_FORMAT = "Incomplete command format! \n%1$s";
     public static final String MESSAGE_INVALID_MISSING_ARGUMENTS = "Missing arguments for the given command! \n%1$s";
-    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
-    public static final String MESSAGE_INVALID_INTERESTS = "Interests should be alphanumeric";
+    public static final String MESSAGE_INVALID_ARGUMENTS = "Missing arguments for the given command! \n%1$s";
+    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid.";
+    public static final String MESSAGE_INVALID_INTERESTS = "Interests should be alphanumeric.";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_ONE_STUDENT_LISTED_OVERVIEW = "%1$d student listed!";
 
 }

--- a/src/main/java/seedu/masslinkers/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/FindCommand.java
@@ -28,9 +28,16 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredStudentList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW,
-                model.getFilteredStudentList().size()), false, false, true, false);
+        int numOfStudents = model.getFilteredStudentList().size();
+        if (numOfStudents != 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW,
+                            numOfStudents), false, false, true, false);
+        } else {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_ONE_STUDENT_LISTED_OVERVIEW,
+                            numOfStudents), false, false, true, false);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/masslinkers/logic/commands/FindInterestCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/FindInterestCommand.java
@@ -27,9 +27,16 @@ public class FindInterestCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredStudentList(predicate);
-        return new CommandResult(
-            String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW,
-                model.getFilteredStudentList().size()), false, false, true, false);
+        int numOfStudents = model.getFilteredStudentList().size();
+        if (numOfStudents != 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW,
+                            numOfStudents), false, false, true, false);
+        } else {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_ONE_STUDENT_LISTED_OVERVIEW,
+                            numOfStudents), false, false, true, false);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/masslinkers/logic/commands/ModAddCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/ModAddCommand.java
@@ -18,7 +18,7 @@ import seedu.masslinkers.ui.MainWindow;
  */
 public class ModAddCommand extends ModCommand {
     public static final String COMMAND_WORD = "add";
-    public static final String MESSAGE_SUCCESS = "Successfully added the specified mods.";
+    public static final String MESSAGE_SUCCESS = "Successfully added the specified mod(s).";
     private MainWindow mainWindow;
     private final Index targetIndex;
     private final ObservableList<Mod> mods;

--- a/src/main/java/seedu/masslinkers/logic/commands/ModDeleteCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/ModDeleteCommand.java
@@ -18,7 +18,7 @@ import seedu.masslinkers.model.student.Student;
 public class ModDeleteCommand extends ModCommand {
 
     public static final String COMMAND_WORD = "delete";
-    public static final String MESSAGE_SUCCESS = "Successfully deleted the specified mods.";
+    public static final String MESSAGE_SUCCESS = "Successfully deleted the specified mod(s).";
     public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified."
             + "\nPlease check the list of mods and try again.";
     private final Index targetIndex;

--- a/src/main/java/seedu/masslinkers/logic/commands/ModFindCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/ModFindCommand.java
@@ -34,9 +34,16 @@ public class ModFindCommand extends ModCommand {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredStudentList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW, model.getFilteredStudentList().size()),
-                false, false, true, false);
+        int numOfStudents = model.getFilteredStudentList().size();
+        if (numOfStudents != 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW, model.getFilteredStudentList().size()),
+                    false, false, true, false);
+        } else {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_ONE_STUDENT_LISTED_OVERVIEW,
+                            numOfStudents), false, false, true, false);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/masslinkers/logic/commands/ModMarkCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/ModMarkCommand.java
@@ -18,7 +18,7 @@ import seedu.masslinkers.model.student.Student;
 public class ModMarkCommand extends ModCommand {
 
     public static final String COMMAND_WORD = "mark";
-    public static final String MESSAGE_SUCCESS = "Successfully marked the specified mods.";
+    public static final String MESSAGE_SUCCESS = "Successfully marked the specified mod(s).";
     public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified.\n"
             + "Please check the list of mods and try again.";
     private final Index targetIndex;

--- a/src/main/java/seedu/masslinkers/logic/commands/ModUnmarkCommand.java
+++ b/src/main/java/seedu/masslinkers/logic/commands/ModUnmarkCommand.java
@@ -18,7 +18,7 @@ import seedu.masslinkers.model.student.Student;
 public class ModUnmarkCommand extends ModCommand {
 
     public static final String COMMAND_WORD = "unmark";
-    public static final String MESSAGE_SUCCESS = "Successfully unmarked the specified mods.";
+    public static final String MESSAGE_SUCCESS = "Successfully unmarked the specified mod(s).";
     public static final String MESSAGE_INVALID_MOD = "This batchmate is not taking all of the modules specified."
             + "\nPlease check the list of mods and try again.";
     private final Index targetIndex;

--- a/src/main/java/seedu/masslinkers/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/AddCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.masslinkers.logic.parser;
 
-import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_ARGUMENTS;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_GITHUB;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_INTEREST;
@@ -37,9 +37,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                 PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM, PREFIX_GITHUB, PREFIX_INTEREST, PREFIX_MOD);
-
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TELEGRAM) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_ARGUMENTS, AddCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
@@ -2,6 +2,7 @@ package seedu.masslinkers.logic.parser;
 
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_INTERESTS;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.parser.ParserUtil.parseIndex;
 
 import java.util.Arrays;
@@ -52,8 +53,7 @@ public class AddInterestCommandParser implements Parser<AddInterestCommand> {
         try {
             index = parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MISSING_ARGUMENTS,
-                    AddInterestCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         if (interestSet.isEmpty()) {

--- a/src/main/java/seedu/masslinkers/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/DeleteCommandParser.java
@@ -1,9 +1,14 @@
 package seedu.masslinkers.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
+
+import java.util.regex.Pattern;
 
 import seedu.masslinkers.commons.core.index.Index;
 import seedu.masslinkers.logic.commands.DeleteCommand;
+import seedu.masslinkers.logic.commands.DeleteInterestCommand;
 import seedu.masslinkers.logic.parser.exceptions.ParseException;
 
 /**
@@ -11,18 +16,27 @@ import seedu.masslinkers.logic.parser.exceptions.ParseException;
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 
+    private static final Pattern INDEX_FORMAT = Pattern.compile("-?\\d+");
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        Index index;
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, DeleteInterestCommand.MESSAGE_USAGE));
+        }
+
         try {
-            Index index = ParserUtil.parseIndex(args);
+            index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, DeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
     }
 

--- a/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.masslinkers.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_INTERESTS;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.parser.ParserUtil.parseIndex;
 
 import java.util.Arrays;
@@ -31,6 +33,7 @@ public class DeleteInterestCommandParser implements Parser<DeleteInterestCommand
      * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteInterestCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         Index index;
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
@@ -51,8 +54,7 @@ public class DeleteInterestCommandParser implements Parser<DeleteInterestCommand
         try {
             index = parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MISSING_ARGUMENTS,
-                    DeleteInterestCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         if (interestSet.isEmpty()) {

--- a/src/main/java/seedu/masslinkers/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.masslinkers.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_GITHUB;
 import static seedu.masslinkers.logic.parser.CliSyntax.PREFIX_INTEREST;
@@ -38,11 +39,16 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_TELEGRAM, PREFIX_GITHUB, PREFIX_INTEREST, PREFIX_MOD);
 
         Index index;
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, EditCommand.MESSAGE_USAGE));
+        }
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         if (!argMultimap.getAllValues(PREFIX_MOD).isEmpty()) {

--- a/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
@@ -127,7 +127,8 @@ public class ModCommandParser implements Parser<ModCommand> {
         try {
             index = ParserUtil.parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModDeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX,
+                    ModAddCommand.MESSAGE_USAGE), pe);
         }
         return new ModDeleteCommand(index, mods.get());
     }
@@ -154,11 +155,11 @@ public class ModCommandParser implements Parser<ModCommand> {
 
         } else {
             try {
-                index = ParserUtil.parseIndex(indexOrAll);
+                String indexFromCommand = getIndexFromCommand(trimmedArgs);
+                index = ParserUtil.parseIndex(indexFromCommand);
             } catch (ParseException pe) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE),
-                        pe);
+                throw new ParseException(String.format(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX,
+                        ModAddCommand.MESSAGE_USAGE), pe);
             }
             return new ModMarkCommand(index, mods.get());
         }
@@ -185,7 +186,8 @@ public class ModCommandParser implements Parser<ModCommand> {
         try {
             index = ParserUtil.parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX,
+                    ModAddCommand.MESSAGE_USAGE), pe);
         }
         return new ModUnmarkCommand(index, mods.get());
     }
@@ -207,7 +209,6 @@ public class ModCommandParser implements Parser<ModCommand> {
         boolean isTaken = keywords[0].equalsIgnoreCase(MOD_TAKEN_COMMAND_WORD);
         boolean isTaking = keywords[0].equalsIgnoreCase(MOD_TAKING_COMMAND_WORD);
         String[] keywordsWithoutFirstElement = Arrays.copyOfRange(keywords, 1, keywords.length);
-
         if ((isTaken || isTaking) && keywordsWithoutFirstElement.length == 0) {
             throw new ParseException(ModCommand.MESSAGE_MODS_EMPTY);
         }

--- a/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
@@ -3,6 +3,7 @@ package seedu.masslinkers.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INCOMPLETE_COMMAND_FORMAT;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,7 +100,8 @@ public class ModCommandParser implements Parser<ModCommand> {
         try {
             index = ParserUtil.parseIndex(indexFromCommand);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX,
+                    ModAddCommand.MESSAGE_USAGE), pe);
         }
         return new ModAddCommand(index, mods.get());
     }

--- a/src/test/java/seedu/masslinkers/logic/commands/FindInterestCommandTest.java
+++ b/src/test/java/seedu/masslinkers/logic/commands/FindInterestCommandTest.java
@@ -3,6 +3,7 @@ package seedu.masslinkers.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_ONE_STUDENT_LISTED_OVERVIEW;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW;
 import static seedu.masslinkers.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.masslinkers.testutil.TypicalStudents.ALICE;
@@ -79,7 +80,7 @@ public class FindInterestCommandTest {
 
     @Test
     public void execute_multipleKeywords_oneStudentFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(MESSAGE_ONE_STUDENT_LISTED_OVERVIEW, 1);
         StudentContainsInterestPredicate predicate = preparePredicate("AI SWE");
         FindInterestCommand command = new FindInterestCommand(predicate);
         expectedModel.updateFilteredStudentList(predicate);

--- a/src/test/java/seedu/masslinkers/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,6 @@
 package seedu.masslinkers.logic.parser;
 
-import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.masslinkers.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.masslinkers.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -27,6 +27,6 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/masslinkers/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.masslinkers.logic.parser;
 
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_MISSING_ARGUMENTS;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.masslinkers.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.masslinkers.logic.commands.CommandTestUtil.INTEREST_DESC_AI;
@@ -57,28 +58,28 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
 
         // no field specified
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_MISSING_ARGUMENTS, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 o/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 o/ string", MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
@@ -163,7 +163,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndexModDelete_throwParseException() {
         assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModDeleteCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     /**
@@ -296,7 +296,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndexModMark_throwParseException() {
         assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModMarkCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     /**
@@ -370,7 +370,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndexModUnmark_throwParseException() {
         assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModUnmarkCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     /**

--- a/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.masslinkers.logic.parser;
 
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INCOMPLETE_COMMAND_FORMAT;
 import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.masslinkers.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.masslinkers.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.masslinkers.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.masslinkers.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -88,7 +89,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_invalidIndex_throwParseException() {
         assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " -1 " + VALID_MOD_STRING_CS2103T,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModAddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX, ModAddCommand.MESSAGE_USAGE));
     }
 
     /**


### PR DESCRIPTION
Previously, invalid indexes were shown as missing argument errors.
Commands edited for invalid index:
- mod find
- findInt
- mod delete
- delete 
- edit
- mod mark
- mod unmark

Correct grammar for Successfully added mod(s)
- mod add
- mod delete
- mod unmark
- mod mark

Corrected grammar 1 -> student.
- find
- mod find 
- findInt

Fixes #195 
Fixes #190 
Fixes #182 
Fixes #177 