### PR TITLE
Multiple Bug Fixes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -644,12 +644,12 @@ testers are expected to do more *exploratory* testing.
 
 1. Adding a batchmate to the data.
 
-    1. Test case: `add n/John t/john`.<br>
-       Expected: A new batchmate with the name `John` and telegram handle `john` is added at the bottom of the students pane in Mass Linkers.
+    1. Test case: `add n/John t/johnnn`.<br>
+       Expected: A new batchmate with the name `John` and telegram handle `johnnn` is added at the bottom of the students pane in Mass Linkers.
        The status message indicates that a batchmate named `John` has been successfully added.
 
-       1. Prerequisite: A batchmate with the name `Tom` and the telegram `tom` is already in Mass Linkers. <br>
-          Test case: `add n/Tom t/tom`.<br>
+       1. Prerequisite: A batchmate with the name `Tom` and the telegram `tommmm` is already in Mass Linkers. <br>
+          Test case: `add n/Tom t/tommmm`.<br>
           Expected: No batchmate is added. The status message indicates that the batchmate already exists in Mass Linkers. 
        Uniqueness is verified using two of the mandatory fields - the ```Student```'s name and telegram handle.
 
@@ -660,7 +660,7 @@ testers are expected to do more *exploratory* testing.
     3. Test case: `add n/John`.<br>
        Expected: No batchmate is added. The status message indicates that the command is of an invalid format.
 
-    4. Other incorrect `add` commands to try: `add`, `add n/John t/john x/invalid`, `...` (where x is any invalid prefix).<br>
+    4. Other incorrect `add` commands to try: `add`, `add n/John t/johnnn x/invalid`, `...` (where x is any invalid prefix).<br>
        Expected: Similar to previous.
 
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -190,8 +190,8 @@ The following activity diagram summarises what happens when a student enters a `
 **Aspect: How `findInt` executes:**
 
 * **Alternative 1 (current choice):** Finds all batchmates whose interests match all interests specified (i.e. a superset of those specified).
-    * Pros: A specific search to find batchmates who have the same interests as the student. (Specifying `AI` and `SWE` will result in a batchmate whose interests are `AI`, `SWE` and `algo` to be displayed).
-    * Cons: Search might be too narrow since it excludes batchmates that have some but not all the interests specified. (Specifying `AI` and `SWE` will not result in a batchmate whose only interest is `AI` to be displayed).
+    * Pros: A specific search to find batchmates who have the same interests as the student. (Specifying `ai` and `swe` will result in a batchmate whose interests are `ai`, `swe` and `algo` to be displayed).
+    * Cons: Search might be too narrow since it excludes batchmates that have some but not all the interests specified. (Specifying `ai` and `swe` will not result in a batchmate whose only interest is `ai` to be displayed).
 
 * **Alternative 2:** Finds all batchmates whose interests match at least one of the interests specified.
     * Pros: A more general search might be useful for finding a greater number of batchmates who share some of the interests as the student.
@@ -653,8 +653,8 @@ testers are expected to do more *exploratory* testing.
           Expected: No batchmate is added. The status message indicates that the batchmate already exists in Mass Linkers. 
        Uniqueness is verified using two of the mandatory fields - the ```Student```'s name and telegram handle.
 
-    2. Test case: `add n/John t/john i/AI g/john`.<br>
-       Expected: A new batchmate with the name `John`, telegram handle `john`, interests `AI` and GitHub `john` is added at the bottom of the students pane in Mass Linkers.
+    2. Test case: `add n/John t/john i/ai g/john`.<br>
+       Expected: A new batchmate with the name `John`, telegram handle `john`, interests `ai` and GitHub `john` is added at the bottom of the students pane in Mass Linkers.
        The status message indicates that a batchname named `John` has been successfully added.
 
     3. Test case: `add n/John`.<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,7 +84,7 @@ Format: `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m
 
 Examples:
 * `add n/John Doe t/johnxyz` adds a batchmate named `John Doe` with telegram handle `johnxyz` to the list.
-* `add n/John Doe t/johnxyz g/john_doe p/98765432 e/johnd@example.com i/AI i/SWE` adds a batchmate named `John Doe` with telegram handle `johnxyz`, github username `john_doe`, phone number `98765432`, email address `johnd@example.com` and interests in `AI` and `SWE` to the list. 
+* `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/AI i/SWE` adds a batchmate named `John Doe` with telegram handle `johnxyz`, github username `johndoe`, phone number `98765432`, email address `johnd@example.com` and interests in `AI` and `SWE` to the list. 
 * `add n/John Doe t/johnxyz m/cs2103t m/cs2101` adds a batchmate named `John Doe` with telegram handle `johnxyz` and modules `cs2103t` and `cs2101` to the list.
 
 ### List all batchmates: `list`
@@ -110,7 +110,7 @@ Format: `edit INDEX [n/NAME] [t/TELEGRAM] [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTE
 * You can remove all the batchmate’s interests by typing `i/` without specifying any interests after it.
 
 Examples:
-*  `edit 1 g/john_doe p/91234567 e/johndoe@example.com` edits the github username, phone number and email address of the 1st batchmate in the currently displayed list to be `john_doe`, `91234567` and `johndoe@example.com` respectively.
+*  `edit 1 g/johndoe p/91234567 e/johndoe@example.com` edits the github username, phone number and email address of the 1st batchmate in the currently displayed list to be `johndoe`, `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Bob Tan i/` edits the name of the 2nd batchmate in the currently displayed list to be `Bob Tan` and clears all existing interests.
 
 ### Find a batchmate: `find`
@@ -291,13 +291,13 @@ Data in Mass Linkers is saved in the hard disk automatically after executing any
 
 Below is the summary of requirements of each parameter for the various commands. 
 
-| Parameter       | Requirements                                        |
-|-----------------|-----------------------------------------------------|
-| Name            | Only alphabetical with spaces allowed.              |
-| Telegram handle | Only alphanumerical and special characters allowed. |
-| Phone number    | Only numerical characters of at least length 3.     |
-| GitHub username | Only alphanumerical and special characters allowed. |
-| Interest        | Only alphanumerical characters allowed.             |
+| Parameter       | Requirements                                                                                                                                                                                   |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name            | Only alphabetical with spaces allowed.                                                                                                                                                         |
+| Telegram handle | Case insensitive. Only contain a-z, 0-9, underscores and have a minimum length of 5 characters.                                                                                                |
+| Phone number    | Only numerical characters of at least length 3.                                                                                                                                                |
+| GitHub username | Case insensitive. Follows the requirements as stated [here](https://github.com/shinnn/github-username-regex#:~:text=Github%20username%20may%20only%20contain,Maximum%20is%2039%20characters.). |
+| Interest        | Only alphanumerical characters allowed.                                                                                                                                                        |
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -335,9 +335,9 @@ _Module prefix refers to the first two characters of every module name._
 | Action                           | Format                                                                                                                                                           | Examples                      |
 |----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
 | **Help**                         | `help`                                                             | `help`                                                                                                                      |
-| **Add**                          | `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m/MODULE]...`| `add n/John Doe t/johnxyz g/john_doe p/98765432 e/johnd@example.com i/AI i/SWE m/cs2103t m/cs2101`         |
+| **Add**                          | `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m/MODULE]...`| `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/AI i/SWE m/cs2103t m/cs2101`         |
 | **List**                         | `list`| `list`                                                                                                                                                                                   |
-| **Edit**                         | `edit INDEX [n/NAME] [t/TELEGRAM] [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]...`| `edit 1 g/john_doe p/91234567 e/johndoe@example.com`                                                          |
+| **Edit**                         | `edit INDEX [n/NAME] [t/TELEGRAM] [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]...`| `edit 1 g/johndoe p/91234567 e/johndoe@example.com`                                                          |
 | **Find**                         | `find KEYWORD [MORE_KEYWORDS]...`| `find Alex david`                                                                                                                                             |
 | **Add interest**                 | `addInt INDEX INTEREST [MORE_INTERESTS]...`| `addInt 3 algo AI SWE`                                                                                                                              |
 | **Delete interest**              | `deleteInt INDEX INTEREST [MORE_INTERESTS]...` | `deleteInt 3 AI SWE`                                                                                                                            |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -41,11 +41,11 @@ In this *User Guide*, we will take you through the many useful features and func
 
 * Items in square brackets are optional.<br>
   Example:
-  * `n/NAME t/TELEGRAM [i/INTEREST]` can be used as `n/John Doe t/johnxyz i/AI` or as `n/John Doe t/johnxyz` without using `i/INTEREST`.
+  * `n/NAME t/TELEGRAM [i/INTEREST]` can be used as `n/John Doe t/johnxyz i/ai` or as `n/John Doe t/johnxyz` without using `i/INTEREST`.
 
 * Items with `...` after them can be used multiple times.<br>
   Examples:
-  * `[i/INTEREST]...` can be used as `i/AI`, `i/algo i/SWE` etc.<br>
+  * `[i/INTEREST]...` can be used as `i/ai`, `i/algo i/swe` etc.<br>
   * `[MORE_MODULES]...` can be used as `cs2100`, `cs2103t cs2101 cs2105` etc.
 
 * Parameters can be in any order.<br>
@@ -84,7 +84,7 @@ Format: `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m
 
 Examples:
 * `add n/John Doe t/johnxyz` adds a batchmate named `John Doe` with telegram handle `johnxyz` to the list.
-* `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/AI i/SWE` adds a batchmate named `John Doe` with telegram handle `johnxyz`, github username `johndoe`, phone number `98765432`, email address `johnd@example.com` and interests in `AI` and `SWE` to the list. 
+* `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/ai i/swe` adds a batchmate named `John Doe` with telegram handle `johnxyz`, github username `johndoe`, phone number `98765432`, email address `johnd@example.com` and interests in `ai` and `swe` to the list. 
 * `add n/John Doe t/johnxyz m/cs2103t m/cs2101` adds a batchmate named `John Doe` with telegram handle `johnxyz` and modules `cs2103t` and `cs2101` to the list.
 
 ### List all batchmates: `list`
@@ -146,7 +146,7 @@ Format: `addInt INDEX INTEREST [MORE_INTERESTS]...`
 
 Examples:
 * `addInt 1 algo` adds the interest `algo` to the 1st batchmate in the currently displayed list.
-* `addInt 3 database SWE MachineLearning` adds the interests `database`, `SWE` and `MachineLearning` to the 3rd batchmate in the currently displayed list.
+* `addInt 3 database swe machinelearning` adds the interests `database`, `swe` and `machinelearning` to the 3rd batchmate in the currently displayed list.
 
 ### Delete interests: `deleteInt`
 
@@ -157,8 +157,8 @@ Format: `deleteInt INDEX INTEREST [MORE_INTERESTS]...`
 * Deletes interest(s) from the batchmate at the specific INDEX in the __currently displayed list__ in the Students panel. Refer to the section on _Notes about parameters_ at the start of [Features](#features) for more details.
 
 Examples:
-* `deleteInt 1 AI` deletes the interest `AI` from the 1st batchmate in the currently displayed list.
-* `deleteInt 3 AI SWE` deletes the interests `AI` and `SWE` from the 3rd batchmate in the currently displayed list.
+* `deleteInt 1 ai` deletes the interest `ai` from the 1st batchmate in the currently displayed list.
+* `deleteInt 3 ai swe` deletes the interests `ai` and `swe` from the 3rd batchmate in the currently displayed list.
 
 ### Find batchmates by interests: `findInt`
 
@@ -166,12 +166,12 @@ Finds batchmates whose interests contain __all__ the specified interests.
 
 Format: `findInt INTEREST [MORE_INTERESTS]...`
 
-* The search is case-insensitive. e.g. `machinelearning` will match `MachineLearning`.
-* Only exact words will be matched. e.g. `sw` will not match `SWE`.
+* The search is case-insensitive. e.g. `machinelearning` will match `machinelearning`.
+* Only exact words will be matched. e.g. `sw` will not match `swe`.
 
 Examples:
-* `findInt AI` returns all batchmates whose interests contain `AI`.
-* `findInt swe security` returns all batchmates whose interests contain both `SWE` and `security`.
+* `findInt ai` returns all batchmates whose interests contain `ai`.
+* `findInt swe security` returns all batchmates whose interests contain both `swe` and `security`.
 
 ### Delete a batchmate: `delete`
 
@@ -335,13 +335,13 @@ _Module prefix refers to the first two characters of every module name._
 | Action                           | Format                                                                                                                                                           | Examples                      |
 |----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
 | **Help**                         | `help`                                                             | `help`                                                                                                                      |
-| **Add**                          | `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m/MODULE]...`| `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/AI i/SWE m/cs2103t m/cs2101`         |
+| **Add**                          | `add n/NAME t/TELEGRAM [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]... [m/MODULE]...`| `add n/John Doe t/johnxyz g/johndoe p/98765432 e/johnd@example.com i/AI i/swe m/cs2103t m/cs2101`         |
 | **List**                         | `list`| `list`                                                                                                                                                                                   |
 | **Edit**                         | `edit INDEX [n/NAME] [t/TELEGRAM] [g/GITHUB] [p/PHONE] [e/EMAIL] [i/INTEREST]...`| `edit 1 g/johndoe p/91234567 e/johndoe@example.com`                                                          |
 | **Find**                         | `find KEYWORD [MORE_KEYWORDS]...`| `find Alex david`                                                                                                                                             |
-| **Add interest**                 | `addInt INDEX INTEREST [MORE_INTERESTS]...`| `addInt 3 algo AI SWE`                                                                                                                              |
-| **Delete interest**              | `deleteInt INDEX INTEREST [MORE_INTERESTS]...` | `deleteInt 3 AI SWE`                                                                                                                            |
-| **Find by interest**             | `findInt INTEREST [MORE_INTEREST]...` | `findInt AI SWE`                                                                                                                                         |
+| **Add interest**                 | `addInt INDEX INTEREST [MORE_INTERESTS]...`| `addInt 3 algo ai swe`                                                                                                                              |
+| **Delete interest**              | `deleteInt INDEX INTEREST [MORE_INTERESTS]...` | `deleteInt 3 ai swe`                                                                                                                            |
+| **Find by interest**             | `findInt INTEREST [MORE_INTEREST]...` | `findInt ai swe`                                                                                                                                         |
 | **Delete**                       | `delete INDEX` | `delete 2`                                                                                                                                                                      |
 | **Add module**                   | `mod add INDEX MODULE [MORE_MODULES]...` | `mod add 3 cs2100 cs2103t cs2101 cs2105`                                                                                                              |
 | **Delete module**                | `mod delete INDEX MODULE [MORE_MODULES]...`| `mod delete 3 cs2100 cs2103t cs2101 cs2105`                                                                                                         |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -291,13 +291,13 @@ Data in Mass Linkers is saved in the hard disk automatically after executing any
 
 Below is the summary of requirements of each parameter for the various commands. 
 
-| Parameter       | Requirements                                                                                                                                                                                  |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Name            | Only alphabetical with spaces allowed.                                                                                                                                                        |
-| Telegram handle | Case insensitive. Only contain `a-z`, `0-9`, underscores and have a minimum length of 5 characters.<br> Consecutive underscores are not allowed.                                                      |
-| Phone number    | Only numerical characters of at least length 3.                                                                                                                                               |
-| GitHub username | Case insensitive. Follows the requirements as stated [here](https://github.com/shinnn/github-username-regex#:~:text=Github%20username%20may%20only%20contain,Maximum%20is%2039%20characters.). |
-| Interest        | Only alphanumerical characters allowed.                                                                                                                                                       |
+| Parameter       | Requirements                                                                                                                                                                                                   |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name            | Only alphabetical with spaces allowed.                                                                                                                                                                         |
+| Telegram handle | Case insensitive. Only contain `a-z`, `0-9`, underscores and have a minimum length of 5 characters.<br> Consecutive underscores are not allowed. <br> Starting or/and ending with underscores are not allowed. |
+| Phone number    | Only numerical characters of at least length 3.                                                                                                                                                                |
+| GitHub username | Case insensitive. Follows the requirements as stated [here](https://github.com/shinnn/github-username-regex#:~:text=Github%20username%20may%20only%20contain,Maximum%20is%2039%20characters.).                 |
+| Interest        | Only alphanumerical characters allowed.                                                                                                                                                                        |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -291,13 +291,13 @@ Data in Mass Linkers is saved in the hard disk automatically after executing any
 
 Below is the summary of requirements of each parameter for the various commands. 
 
-| Parameter       | Requirements                                                                                                                                                                                   |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Name            | Only alphabetical with spaces allowed.                                                                                                                                                         |
-| Telegram handle | Case insensitive. Only contain a-z, 0-9, underscores and have a minimum length of 5 characters.                                                                                                |
-| Phone number    | Only numerical characters of at least length 3.                                                                                                                                                |
+| Parameter       | Requirements                                                                                                                                                                                  |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name            | Only alphabetical with spaces allowed.                                                                                                                                                        |
+| Telegram handle | Case insensitive. Only contain `a-z`, `0-9`, underscores and have a minimum length of 5 characters.<br> Consecutive underscores are not allowed.                                                      |
+| Phone number    | Only numerical characters of at least length 3.                                                                                                                                               |
 | GitHub username | Case insensitive. Follows the requirements as stated [here](https://github.com/shinnn/github-username-regex#:~:text=Github%20username%20may%20only%20contain,Maximum%20is%2039%20characters.). |
-| Interest        | Only alphanumerical characters allowed.                                                                                                                                                        |
+| Interest        | Only alphanumerical characters allowed.                                                                                                                                                       |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/AddInterestCommandParser.java
@@ -70,7 +70,7 @@ public class AddInterestCommandParser implements Parser<AddInterestCommand> {
      * @return The index of the student in String.
      */
     private String getIndexFromCommand(String args) throws ParseException {
-        String[] splittedArgs = args.split(" ");
+        String[] splittedArgs = args.split("\\s+");
         String index = splittedArgs[0];
         final Matcher matcher = INDEX_FORMAT.matcher(index.trim());
         if (!matcher.matches()) {
@@ -86,7 +86,7 @@ public class AddInterestCommandParser implements Parser<AddInterestCommand> {
      * @return A set of interests of type Interest.
      */
     private Set<Interest> getInterestsFromCommand(String args) {
-        String[] splitArgs = args.split(" ");
+        String[] splitArgs = args.split("\\s+");
         return Arrays.stream(splitArgs)
                 .skip(1)
                 .map(Interest::new)

--- a/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/DeleteInterestCommandParser.java
@@ -69,7 +69,7 @@ public class DeleteInterestCommandParser implements Parser<DeleteInterestCommand
      * @return The index of the student in String.
      */
     private String getIndexFromCommand(String args) throws ParseException {
-        String[] splitArgs = args.split(" ");
+        String[] splitArgs = args.split("\\s+");
         String index = splitArgs[0];
         final Matcher matcher = INDEX_FORMAT.matcher(index.trim());
         if (!matcher.matches()) {
@@ -85,7 +85,7 @@ public class DeleteInterestCommandParser implements Parser<DeleteInterestCommand
      * @return A set of interests of type Interest.
      */
     private Set<Interest> getInterestsFromCommand(String args) {
-        String[] splitArgs = args.split(" ");
+        String[] splitArgs = args.split("\\s+");
         return Arrays.stream(splitArgs)
                 .skip(1)
                 .map(Interest::new)

--- a/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
+++ b/src/main/java/seedu/masslinkers/logic/parser/ModCommandParser.java
@@ -245,7 +245,7 @@ public class ModCommandParser implements Parser<ModCommand> {
      * @return The index of the student in String.
      */
     private String getIndexFromCommand(String args) throws ParseException {
-        String[] splittedArgs = args.split(" ");
+        String[] splittedArgs = args.split("\\s+");
         String index = splittedArgs[0];
         final Matcher matcher = INDEX_FORMAT.matcher(index.trim());
         if (!matcher.matches()) {
@@ -261,7 +261,7 @@ public class ModCommandParser implements Parser<ModCommand> {
      * @return The index of the student in String or the word "all".
      */
     private String getModMarkIndexOrAll(String args) throws ParseException {
-        String[] splittedArgs = args.split(" ");
+        String[] splittedArgs = args.split("\\s+");
         String indexOrAll = splittedArgs[0].trim();
         boolean isAll = indexOrAll.equals("all");
 
@@ -284,7 +284,7 @@ public class ModCommandParser implements Parser<ModCommand> {
      * @return A set of mods of type String.
      */
     private Set<String> getModsFromCommand(String args) {
-        String[] splittedArgs = args.split(" ");
+        String[] splittedArgs = args.split("\\s+");
         List<String> extractedMods = Arrays.asList(splittedArgs).subList(1, splittedArgs.length);
         return new HashSet<>(extractedMods);
     }

--- a/src/main/java/seedu/masslinkers/model/interest/Interest.java
+++ b/src/main/java/seedu/masslinkers/model/interest/Interest.java
@@ -22,7 +22,7 @@ public class Interest {
     public Interest(String interestName) {
         requireNonNull(interestName);
         checkArgument(isValidInterest(interestName), MESSAGE_CONSTRAINTS);
-        this.interestName = interestName;
+        this.interestName = interestName.toLowerCase();
     }
 
     /**
@@ -41,7 +41,7 @@ public class Interest {
 
     @Override
     public int hashCode() {
-        return interestName.toLowerCase().hashCode();
+        return interestName.hashCode();
     }
 
     /**

--- a/src/main/java/seedu/masslinkers/model/student/GitHub.java
+++ b/src/main/java/seedu/masslinkers/model/student/GitHub.java
@@ -9,14 +9,15 @@ import static seedu.masslinkers.commons.util.AppUtil.checkArgument;
  */
 public class GitHub {
 
+    // GitHub username constraints adapted from https://github.com/shinnn/github-username-regex
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+                    "Github username may only contain alphanumeric characters or hyphens.\n"
+                    + "Github username cannot have multiple consecutive hyphens.\n"
+                    + "Github username cannot begin or end with a hyphen.\n"
+                    + "Between 1 to 39 characters.";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    // Regex adapted from: https://github.com/shinnn/github-username-regex
+    public static final String VALIDATION_REGEX = "^[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}$";
 
     public final String username;
 
@@ -28,14 +29,14 @@ public class GitHub {
     public GitHub(String name) {
         requireNonNull(name);
         checkArgument(isValidGitHub(name), MESSAGE_CONSTRAINTS);
-        username = name;
+        username = name.toLowerCase();
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid GitHub username.
      */
     public static boolean isValidGitHub(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.toLowerCase().matches(VALIDATION_REGEX);
     }
 
 

--- a/src/main/java/seedu/masslinkers/model/student/GitHub.java
+++ b/src/main/java/seedu/masslinkers/model/student/GitHub.java
@@ -11,8 +11,7 @@ public class GitHub {
 
     // GitHub username constraints adapted from https://github.com/shinnn/github-username-regex
     public static final String MESSAGE_CONSTRAINTS =
-                    "GitHub username is case insensitive.\n"
-                    + "Github username may only contain alphanumeric characters or hyphens.\n"
+                    "Github username may only contain alphanumeric characters or hyphens.\n"
                     + "Github username cannot have multiple consecutive hyphens.\n"
                     + "Github username cannot begin or end with a hyphen.\n"
                     + "Between 1 to 39 characters.";

--- a/src/main/java/seedu/masslinkers/model/student/GitHub.java
+++ b/src/main/java/seedu/masslinkers/model/student/GitHub.java
@@ -11,7 +11,8 @@ public class GitHub {
 
     // GitHub username constraints adapted from https://github.com/shinnn/github-username-regex
     public static final String MESSAGE_CONSTRAINTS =
-                    "Github username may only contain alphanumeric characters or hyphens.\n"
+                    "GitHub username is case insensitive.\n"
+                    + "Github username may only contain alphanumeric characters or hyphens.\n"
                     + "Github username cannot have multiple consecutive hyphens.\n"
                     + "Github username cannot begin or end with a hyphen.\n"
                     + "Between 1 to 39 characters.";

--- a/src/main/java/seedu/masslinkers/model/student/Telegram.java
+++ b/src/main/java/seedu/masslinkers/model/student/Telegram.java
@@ -9,8 +9,8 @@ import static seedu.masslinkers.commons.util.AppUtil.checkArgument;
  */
 public class Telegram {
 
-    public static final String MESSAGE_CONSTRAINTS = "Telegram handle can only contain a-z, 0-9, "
-            + "underscores and have a minimum length of 5 characters.";
+    public static final String MESSAGE_CONSTRAINTS = "Telegram handle is case insensitive and "
+            + "can only contain a-z, 0-9, underscores and have a minimum length of 5 characters.";
 
     // Regex adapted from:
     // https://stackoverflow.com/questions/63308185/regex-match-telegram-username-and-delete-whole-line-in-php

--- a/src/main/java/seedu/masslinkers/model/student/Telegram.java
+++ b/src/main/java/seedu/masslinkers/model/student/Telegram.java
@@ -9,8 +9,10 @@ import static seedu.masslinkers.commons.util.AppUtil.checkArgument;
  */
 public class Telegram {
 
-    public static final String MESSAGE_CONSTRAINTS = "Telegram handle is case insensitive and "
-            + "can only contain a-z, 0-9, underscores and have a minimum length of 5 characters.";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Telegram handle may only contain alphanumeric characters or underscores.\n"
+            + "Telegram handle cannot have multiple consecutive underscores.\n"
+            + "Telegram handle cannot begin or end with an underscore.";
 
     // Regex adapted from:
     // https://stackoverflow.com/questions/63308185/regex-match-telegram-username-and-delete-whole-line-in-php

--- a/src/main/java/seedu/masslinkers/model/student/Telegram.java
+++ b/src/main/java/seedu/masslinkers/model/student/Telegram.java
@@ -9,13 +9,12 @@ import static seedu.masslinkers.commons.util.AppUtil.checkArgument;
  */
 public class Telegram {
 
-    public static final String MESSAGE_CONSTRAINTS = "Telegram handle can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Telegram handle can only contain a-z, 0-9, "
+            + "underscores and have a minimum length of 5 characters.";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    // Regex adapted from:
+    // https://stackoverflow.com/questions/63308185/regex-match-telegram-username-and-delete-whole-line-in-php
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*";
 
     public final String handle;
 
@@ -27,14 +26,16 @@ public class Telegram {
     public Telegram(String handle) {
         requireNonNull(handle);
         checkArgument(isValidTelegram(handle), MESSAGE_CONSTRAINTS);
-        this.handle = handle;
+        this.handle = handle.toLowerCase();
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Checks if telegram provided is valid.
+     * Checks follow that of telegram's guidelines:
+     * "You can use a-z, 0-9, underscores. Minimum length is 5 characters."
      */
     public static boolean isValidTelegram(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.length() >= 5 && test.toLowerCase().matches(VALIDATION_REGEX);
     }
 
     @Override
@@ -46,7 +47,7 @@ public class Telegram {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Telegram // instanceof handles nulls
-                && handle.toUpperCase().equals(((Telegram) other).handle.toUpperCase())); // state check
+                && handle.equalsIgnoreCase(((Telegram) other).handle)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/masslinkers/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/masslinkers/model/util/SampleDataUtil.java
@@ -27,7 +27,7 @@ public class SampleDataUtil {
                 new Telegram("ayeoh"), new GitHub("alexyeow"),
                 getInterestsSet("AI"), getModSet("CS2100")),
             new Student(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Telegram("bernieyu"), new GitHub("ber_yu"),
+                new Telegram("bernieyu"), new GitHub("beryu"),
                 getInterestsSet("java", "AI"), getModSet("CS2100")),
             new Student(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Telegram("charl0tte0liveir0"), new GitHub("charlotte123"),
@@ -39,7 +39,7 @@ public class SampleDataUtil {
                 new Telegram("irfanibrahim"), new GitHub("irfanibrahim"),
                 getInterestsSet("algo"), getModSet("CS2100")),
             new Student(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Telegram("roybala"), new GitHub("bala_roy"),
+                new Telegram("roybala"), new GitHub("balaroy"),
                 getInterestsSet("java"), getModSet("CS2100"))
         };
     }

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/18"
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11"
          xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -16,7 +16,7 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <fx:root minHeight="600" minWidth="700" onCloseRequest="#handleExit" title="Mass Linkers"
-         type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
+         type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/ModListCard.fxml
+++ b/src/main/resources/view/ModListCard.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox fx:id="modCardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox fx:id="modCardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/ModListPanel.fxml
+++ b/src/main/resources/view/ModListPanel.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="modListView" VBox.vgrow="ALWAYS" />
 </VBox>
 

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/11"
     xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" text="Enter help to get started."
             styleClass="result-display" promptText="Command output..."/>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 
-<GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
   </columnConstraints>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -11,7 +11,7 @@
 
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.image.Image?>
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/StudentListPanel.fxml
+++ b/src/main/resources/view/StudentListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="studentListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/data/JsonSerializableMassLinkersTest/typicalStudentsMassLinkers.json
+++ b/src/test/data/JsonSerializableMassLinkersTest/typicalStudentsMassLinkers.json
@@ -69,7 +69,7 @@
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "handle" : "fionalim",
-    "username" : "EDXs",
+    "username" : "fiona",
     "mods" : [ {
       "modName" : "CS2100",
       "hasTaken" : false

--- a/src/test/java/seedu/masslinkers/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/masslinkers/logic/commands/CommandTestUtil.java
@@ -37,7 +37,7 @@ public class CommandTestUtil {
     public static final String VALID_TELEGRAM_AMY = "amy123";
     public static final String VALID_TELEGRAM_BOB = "bobby";
     public static final String VALID_GITHUB_AMY = "amybee";
-    public static final String VALID_GITHUB_BOB = "bobby_choo";
+    public static final String VALID_GITHUB_BOB = "bobbychoo";
     public static final String VALID_INTEREST_SWE = "SWE";
     public static final String VALID_INTEREST_AI = "AI";
     public static final String VALID_MOD_CS2100 = "CS2100";

--- a/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/ModCommandParserTest.java
@@ -30,6 +30,7 @@ public class ModCommandParserTest {
     private static final String VALID_MOD_STRING_CS2103T = "CS2103T";
     private static final String VALID_MOD_STRING_CS2101 = "CS2101";
     private static final String VALID_MOD_STRING_CS2100 = "CS2100";
+    private static final String WHITESPACE = " ";
     private final ModCommandParser parser = new ModCommandParser();
 
     /**
@@ -47,17 +48,20 @@ public class ModCommandParserTest {
     @Test
     public void parse_unknownCommand_throwParseException() {
         assertParseFailure(parser,
-                INVALID_MOD_COMMAND + " " + INDEX_FIRST_STUDENT.getOneBased() + " " + VALID_MOD_STRING_CS2103T,
+                INVALID_MOD_COMMAND + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased() + WHITESPACE
+                        + VALID_MOD_STRING_CS2103T,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 ModCommand.MESSAGE_USAGE));
     }
+
+    //// ------------------------------------ MOD ADD COMMAND -----------------------------------------------////
 
     /**
      * Tests the behaviour of mod add when index is absent.
      */
     @Test
     public void parse_noIndex_throwParseException() {
-        assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+        assertParseFailure(parser, ModAddCommand.COMMAND_WORD + WHITESPACE + VALID_MOD_STRING_CS2103T,
                 ModCommand.MESSAGE_INDEX_EMPTY);
     }
 
@@ -66,7 +70,7 @@ public class ModCommandParserTest {
      */
     @Test
     public void parse_noMods_throwParseException() {
-        assertParseFailure(parser, ModAddCommand.COMMAND_WORD + " " + INDEX_FIRST_STUDENT.getOneBased(),
+        assertParseFailure(parser, ModAddCommand.COMMAND_WORD + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased(),
                 ModCommand.MESSAGE_MODS_EMPTY);
     }
 
@@ -77,8 +81,8 @@ public class ModCommandParserTest {
     public void parse_invalidMod_throwParseException() {
         assertParseFailure(parser,
                 ModAddCommand.COMMAND_WORD
-                        + " " + INDEX_FIRST_STUDENT.getOneBased()
-                        + " " + INVALID_MOD_STRING,
+                        + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased()
+                        + WHITESPACE + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -97,8 +101,25 @@ public class ModCommandParserTest {
     @Test
     public void parse_oneMod_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModAddCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T;
+        String userInput = ModAddCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T;
+
+        ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
+        ModAddCommand expectedCommand = new ModAddCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of adding 1 mod with additional whitespace.
+     */
+    @Test
+    public void parse_oneModWithExtraWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModAddCommand.COMMAND_WORD + WHITESPACE + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + WHITESPACE
+                + VALID_MOD_STRING_CS2103T;
 
         ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
         ModAddCommand expectedCommand = new ModAddCommand(targetIndex, mods);
@@ -112,10 +133,10 @@ public class ModCommandParserTest {
     @Test
     public void parse_manyMods_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModAddCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T
-                + " " + VALID_MOD_STRING_CS2101
-                + " " + VALID_MOD_STRING_CS2100;
+        String userInput = ModAddCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
 
         ObservableList<Mod> mods = FXCollections.observableArrayList();
         mods.add(new Mod(VALID_MOD_STRING_CS2100));
@@ -127,11 +148,35 @@ public class ModCommandParserTest {
     }
 
     /**
+     * Tests the behaviour of adding multiple mods with additional whitespace
+     */
+    @Test
+    public void parse_manyModsWithExtraWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModAddCommand.COMMAND_WORD + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModAddCommand expectedCommand = new ModAddCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+    //// ------------------------------------ MOD DELETE COMMAND -----------------------------------------------////
+
+    /**
      * Tests the behaviour of mod delete when index is absent.
      */
     @Test
     public void parse_noIndexModDelete_throwParseException() {
-        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + WHITESPACE + VALID_MOD_STRING_CS2103T,
                 ModCommand.MESSAGE_INDEX_EMPTY);
     }
 
@@ -140,7 +185,7 @@ public class ModCommandParserTest {
      */
     @Test
     public void parse_noModsModDelete_throwParseException() {
-        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_STUDENT.getOneBased(),
+        assertParseFailure(parser, ModDeleteCommand.COMMAND_WORD + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased(),
                 ModCommand.MESSAGE_MODS_EMPTY);
     }
 
@@ -151,8 +196,8 @@ public class ModCommandParserTest {
     public void parse_invalidModModDelete_throwParseException() {
         assertParseFailure(parser,
                 ModDeleteCommand.COMMAND_WORD
-                        + " " + INDEX_FIRST_STUDENT.getOneBased()
-                        + " " + INVALID_MOD_STRING,
+                        + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased()
+                        + WHITESPACE + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -171,8 +216,8 @@ public class ModCommandParserTest {
     @Test
     public void parse_deleteOneMod_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModDeleteCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T;
+        String userInput = ModDeleteCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T;
 
         ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
         ModDeleteCommand expectedCommand = new ModDeleteCommand(targetIndex, mods);
@@ -186,10 +231,10 @@ public class ModCommandParserTest {
     @Test
     public void parse_deleteMultipleMods_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModDeleteCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T
-                + " " + VALID_MOD_STRING_CS2101
-                + " " + VALID_MOD_STRING_CS2100;
+        String userInput = ModDeleteCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
 
         ObservableList<Mod> mods = FXCollections.observableArrayList();
         mods.add(new Mod(VALID_MOD_STRING_CS2100));
@@ -201,11 +246,34 @@ public class ModCommandParserTest {
     }
 
     /**
+     * Tests the behaviour of deleting multiple mods with additional whitespace.
+     */
+    @Test
+    public void parse_deleteMultipleModsWithExtraWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModDeleteCommand.COMMAND_WORD + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModDeleteCommand expectedCommand = new ModDeleteCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    //// ------------------------------------ MOD FIND COMMAND -----------------------------------------------////
+
+    /**
      * Tests the behaviour of mod find when no module is entered.
      */
     @Test
     public void parse_findEmptyString_throwsParseException() {
-        assertParseFailure(parser, ModFindCommand.COMMAND_WORD + " " + "     ", String.format(
+        assertParseFailure(parser, ModFindCommand.COMMAND_WORD + WHITESPACE, String.format(
                 ModCommand.MESSAGE_MODS_EMPTY));
     }
 
@@ -214,7 +282,7 @@ public class ModCommandParserTest {
      */
     @Test
     public void parse_findTakenEmptyString_throwsParseException() {
-        assertParseFailure(parser, ModFindCommand.COMMAND_WORD + " " + ModFindCommand.COMMAND_WORD_TAKEN
+        assertParseFailure(parser, ModFindCommand.COMMAND_WORD + WHITESPACE + ModFindCommand.COMMAND_WORD_TAKEN
                 + "     ", String.format(ModCommand.MESSAGE_MODS_EMPTY));
     }
 
@@ -224,7 +292,7 @@ public class ModCommandParserTest {
     @Test
     public void parse_modFind_success() {
         String userInput = ModFindCommand.COMMAND_WORD
-                + " " + VALID_MOD_STRING_CS2100;
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
         ModFindCommand expectedCommand = new ModFindCommand(
                 new ModContainsKeywordsPredicate(Arrays.asList(VALID_MOD_STRING_CS2100)));
         assertParseSuccess(parser, userInput,
@@ -237,8 +305,22 @@ public class ModCommandParserTest {
     @Test
     public void parse_modFindTaken_success() {
         String userInput = ModFindCommand.COMMAND_WORD
-                + " " + ModFindCommand.COMMAND_WORD_TAKEN
-                + " " + VALID_MOD_STRING_CS2100;
+                + WHITESPACE + ModFindCommand.COMMAND_WORD_TAKEN
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
+        ModFindCommand expectedCommand = new ModFindCommand(
+                new ModTakenContainsKeywordsPredicate(Arrays.asList(VALID_MOD_STRING_CS2100)));
+        assertParseSuccess(parser, userInput,
+                expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of mod find taken with whitespace.
+     */
+    @Test
+    public void parse_modFindTakenWithWhitespace_success() {
+        String userInput = ModFindCommand.COMMAND_WORD
+                + WHITESPACE + WHITESPACE + ModFindCommand.COMMAND_WORD_TAKEN
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100 + WHITESPACE;
         ModFindCommand expectedCommand = new ModFindCommand(
                 new ModTakenContainsKeywordsPredicate(Arrays.asList(VALID_MOD_STRING_CS2100)));
         assertParseSuccess(parser, userInput,
@@ -251,8 +333,8 @@ public class ModCommandParserTest {
     @Test
     public void parse_modFindTaking_success() {
         String userInput = ModFindCommand.COMMAND_WORD
-                + " " + ModFindCommand.COMMAND_WORD_TAKING
-                + " " + VALID_MOD_STRING_CS2100;
+                + WHITESPACE + ModFindCommand.COMMAND_WORD_TAKING
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
         ModFindCommand expectedCommand = new ModFindCommand(
                 new ModTakingContainsKeywordsPredicate(Arrays.asList(VALID_MOD_STRING_CS2100)));
         assertParseSuccess(parser, userInput,
@@ -260,11 +342,27 @@ public class ModCommandParserTest {
     }
 
     /**
+     * Tests the behaviour of mod find taking with whitespace.
+     */
+    @Test
+    public void parse_modFindTakingWithWhitespace_success() {
+        String userInput = ModFindCommand.COMMAND_WORD
+                + WHITESPACE + WHITESPACE + ModFindCommand.COMMAND_WORD_TAKING
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100 + WHITESPACE;
+        ModFindCommand expectedCommand = new ModFindCommand(
+                new ModTakingContainsKeywordsPredicate(Arrays.asList(VALID_MOD_STRING_CS2100)));
+        assertParseSuccess(parser, userInput,
+                expectedCommand);
+    }
+
+    //// ------------------------------------ MOD MARK COMMAND -----------------------------------------------////
+
+    /**
      * Tests the behaviour of mod mark when index is absent.
      */
     @Test
     public void parse_noIndexModMark_throwParseException() {
-        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + WHITESPACE + VALID_MOD_STRING_CS2103T,
                 ModCommand.MESSAGE_INDEX_EMPTY);
     }
 
@@ -273,7 +371,7 @@ public class ModCommandParserTest {
      */
     @Test
     public void parse_noModsModMark_throwParseException() {
-        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + " " + INDEX_FIRST_STUDENT.getOneBased(),
+        assertParseFailure(parser, ModMarkCommand.COMMAND_WORD + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased(),
                 ModCommand.MESSAGE_MODS_EMPTY);
     }
 
@@ -284,8 +382,8 @@ public class ModCommandParserTest {
     public void parse_invalidModModMark_throwParseException() {
         assertParseFailure(parser,
                 ModMarkCommand.COMMAND_WORD
-                        + " " + INDEX_FIRST_STUDENT.getOneBased()
-                        + " " + INVALID_MOD_STRING,
+                        + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased()
+                        + WHITESPACE + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -304,8 +402,24 @@ public class ModCommandParserTest {
     @Test
     public void parse_markOneMod_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModMarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T;
+        String userInput = ModMarkCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T;
+
+        ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
+        ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of marking 1 mod as taken with whitespace.
+     */
+    @Test
+    public void parse_markOneModWithWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModMarkCommand.COMMAND_WORD + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2103T + WHITESPACE;
 
         ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
         ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
@@ -319,10 +433,10 @@ public class ModCommandParserTest {
     @Test
     public void parse_markMultipleMods_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModMarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T
-                + " " + VALID_MOD_STRING_CS2101
-                + " " + VALID_MOD_STRING_CS2100;
+        String userInput = ModMarkCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
 
         ObservableList<Mod> mods = FXCollections.observableArrayList();
         mods.add(new Mod(VALID_MOD_STRING_CS2100));
@@ -334,11 +448,34 @@ public class ModCommandParserTest {
     }
 
     /**
+     * Tests the behaviour of marking multiple mods as taken with whitespace.
+     */
+    @Test
+    public void parse_markMultipleModsWithWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModMarkCommand.COMMAND_WORD + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100 + WHITESPACE;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModMarkCommand expectedCommand = new ModMarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    //// ------------------------------------ MOD UNMARK COMMAND -----------------------------------------------////
+
+    /**
      * Tests the behaviour of mod unmark when index is absent.
      */
     @Test
     public void parse_noIndexModUnmark_throwParseException() {
-        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " " + VALID_MOD_STRING_CS2103T,
+        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + WHITESPACE + VALID_MOD_STRING_CS2103T,
                 ModCommand.MESSAGE_INDEX_EMPTY);
     }
 
@@ -347,7 +484,7 @@ public class ModCommandParserTest {
      */
     @Test
     public void parse_noModsModUnmark_throwParseException() {
-        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + " " + INDEX_FIRST_STUDENT.getOneBased(),
+        assertParseFailure(parser, ModUnmarkCommand.COMMAND_WORD + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased(),
                 ModCommand.MESSAGE_MODS_EMPTY);
     }
 
@@ -358,8 +495,8 @@ public class ModCommandParserTest {
     public void parse_invalidModModUnmark_throwParseException() {
         assertParseFailure(parser,
                 ModUnmarkCommand.COMMAND_WORD
-                        + " " + INDEX_FIRST_STUDENT.getOneBased()
-                        + " " + INVALID_MOD_STRING,
+                        + WHITESPACE + INDEX_FIRST_STUDENT.getOneBased()
+                        + WHITESPACE + INVALID_MOD_STRING,
                 Mod.MESSAGE_CONSTRAINTS);
     }
 
@@ -378,8 +515,8 @@ public class ModCommandParserTest {
     @Test
     public void parse_unmarkOneMod_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModUnmarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T;
+        String userInput = ModUnmarkCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T;
 
         ObservableList<Mod> mods = FXCollections.singletonObservableList(new Mod(VALID_MOD_STRING_CS2103T));
         ModUnmarkCommand expectedCommand = new ModUnmarkCommand(targetIndex, mods);
@@ -393,10 +530,31 @@ public class ModCommandParserTest {
     @Test
     public void parse_unmarkMultipleMods_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
-        String userInput = ModUnmarkCommand.COMMAND_WORD + " " + targetIndex.getOneBased()
-                + " " + VALID_MOD_STRING_CS2103T
-                + " " + VALID_MOD_STRING_CS2101
-                + " " + VALID_MOD_STRING_CS2100;
+        String userInput = ModUnmarkCommand.COMMAND_WORD + WHITESPACE + targetIndex.getOneBased()
+                + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + VALID_MOD_STRING_CS2100;
+
+        ObservableList<Mod> mods = FXCollections.observableArrayList();
+        mods.add(new Mod(VALID_MOD_STRING_CS2100));
+        mods.add(new Mod(VALID_MOD_STRING_CS2103T));
+        mods.add(new Mod(VALID_MOD_STRING_CS2101));
+        ModUnmarkCommand expectedCommand = new ModUnmarkCommand(targetIndex, mods);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the behaviour of unmarking multiple mods as not taken with whitespace.
+     */
+    @Test
+    public void parse_unmarkMultipleModsWithWhitespace_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = ModUnmarkCommand.COMMAND_WORD + WHITESPACE + WHITESPACE
+                + targetIndex.getOneBased()
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2103T
+                + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2101
+                + WHITESPACE + WHITESPACE + WHITESPACE + VALID_MOD_STRING_CS2100 + WHITESPACE;
 
         ObservableList<Mod> mods = FXCollections.observableArrayList();
         mods.add(new Mod(VALID_MOD_STRING_CS2100));

--- a/src/test/java/seedu/masslinkers/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/masslinkers/logic/parser/ParserUtilTest.java
@@ -28,12 +28,14 @@ public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
-    private static final String INVALID_GITHUB = " ";
+    private static final String INVALID_GITHUB = "-invalid-";
+    private static final String INVALID_TELEGRAM = "s";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_INTEREST = "#tennis";
     private static final String INVALID_MOD = "#CS2103";
 
     private static final String VALID_GITHUB = "racheltan";
+    private static final String VALID_TELEGRAM = "racheltan";
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
@@ -133,16 +135,21 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTelegram_validValueWithoutWhitespace_returnsAddress() throws Exception {
-        Telegram expectedAddress = new Telegram(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseTelegram(VALID_ADDRESS));
+    public void parseTelegram_validValueWithoutWhitespace_returnsTelegram() throws Exception {
+        Telegram expectedTelegram = new Telegram(VALID_TELEGRAM);
+        assertEquals(expectedTelegram, ParserUtil.parseTelegram(VALID_TELEGRAM));
     }
 
     @Test
-    public void parseAddress_validValueWithWhitespace_returnsTrimmedAddress() throws Exception {
-        String addressWithWhitespace = WHITESPACE + VALID_ADDRESS + WHITESPACE;
-        Telegram expectedAddress = new Telegram(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseTelegram(addressWithWhitespace));
+    public void parseTelegram_validValueWithWhitespace_returnsTelegram() throws Exception {
+        String telegramWithWhitespace = WHITESPACE + VALID_TELEGRAM + WHITESPACE;
+        Telegram expectedTelegram = new Telegram(VALID_TELEGRAM);
+        assertEquals(expectedTelegram, ParserUtil.parseTelegram(telegramWithWhitespace));
+    }
+
+    @Test
+    public void parseTelegram_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseEmail(INVALID_TELEGRAM));
     }
 
     @Test

--- a/src/test/java/seedu/masslinkers/model/student/DetailsContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/masslinkers/model/student/DetailsContainsKeywordsPredicateTest.java
@@ -64,19 +64,19 @@ public class DetailsContainsKeywordsPredicateTest {
         predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street",
                 "AliceInTheWonderLand"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegram("Main Street")
+                .withEmail("alice@email.com").withTelegram("MainStreet")
                 .withGitHub("AliceInTheWonderLand").build()));
 
         // Keywords matching github username
         predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("aliceinthewonderland"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegram("Main Street")
+                .withEmail("alice@email.com").withTelegram("MainStreet")
                 .withGitHub("AliceInTheWonderLand").build()));
 
         // Keywords containing partially-matching github username
         predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("wonderland"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegram("Main Street")
+                .withEmail("alice@email.com").withTelegram("MainStreet")
                 .withGitHub("AliceInTheWonderLand").build()));
 
         // Keywords containing partially-matching telegram handle
@@ -106,13 +106,13 @@ public class DetailsContainsKeywordsPredicateTest {
         // Array containing no matching keyword
         predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("jonasGoh"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegram("Main Street")
+                .withEmail("alice@email.com").withTelegram("MainStreet")
                 .withGitHub("AliceInTheWonderLand").build()));
 
         // Array containing no matching keyword
         predicate = new DetailsContainsKeywordsPredicate(Arrays.asList("999"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegram("Main Street")
+                .withEmail("alice@email.com").withTelegram("MainStreet")
                 .withGitHub("AliceInTheWonderLand").build()));
 
     }

--- a/src/test/java/seedu/masslinkers/model/student/GitHubTest.java
+++ b/src/test/java/seedu/masslinkers/model/student/GitHubTest.java
@@ -1,0 +1,45 @@
+package seedu.masslinkers.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.masslinkers.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class GitHubTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new GitHub(null));
+    }
+
+    @Test
+    public void constructor_invalidGithub_throwsIllegalArgumentException() {
+        String invalidGithub = "";
+        assertThrows(IllegalArgumentException.class, () -> new GitHub(invalidGithub));
+    }
+
+    @Test
+    public void isValidGitHub() {
+        // null GitHub
+        assertThrows(NullPointerException.class, () -> GitHub.isValidGitHub(null));
+
+        // invalid GitHub
+        assertFalse(GitHub.isValidGitHub("")); // empty string
+        assertFalse(GitHub.isValidGitHub(" ")); // spaces only
+        assertFalse(GitHub.isValidGitHub("-hello")); // starts with hyphen
+        assertFalse(GitHub.isValidGitHub("lopie-")); // ends with hyphen
+        assertFalse(GitHub.isValidGitHub("ld--dfk-fesd")); // > 1 consecutive hyphen
+        assertFalse(GitHub.isValidGitHub("qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm")); // >31 chars
+        assertFalse(GitHub.isValidGitHub("lopi&e")); // special chars that are not hyphens
+
+        // valid GitHub
+        assertTrue(GitHub.isValidGitHub("1")); // exactly 1 number
+        assertTrue(GitHub.isValidGitHub("a")); // exactly 1 letter
+        assertTrue(GitHub.isValidGitHub("jammy12")); // words and numbers
+        assertTrue(GitHub.isValidGitHub("JAMMdfg")); // caps
+        assertTrue(GitHub.isValidGitHub("12345")); // numbers
+        assertTrue(GitHub.isValidGitHub("jdf-3wj")); // one hyphen
+        assertTrue(GitHub.isValidGitHub("ld-dfk-fesd")); // > 1 hyphen
+    }
+}

--- a/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
+++ b/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
@@ -14,23 +14,27 @@ public class TelegramTest {
     }
 
     @Test
-    public void constructor_invalidAddress_throwsIllegalArgumentException() {
-        String invalidAddress = "";
-        assertThrows(IllegalArgumentException.class, () -> new Telegram(invalidAddress));
+    public void constructor_invalidTelegram_throwsIllegalArgumentException() {
+        String invalidTelegram = "";
+        assertThrows(IllegalArgumentException.class, () -> new Telegram(invalidTelegram));
     }
 
     @Test
     public void isValidTelegram() {
-        // null address
+        // null telegram
         assertThrows(NullPointerException.class, () -> Telegram.isValidTelegram(null));
 
-        // invalid addresses
+        // invalid telegram
         assertFalse(Telegram.isValidTelegram("")); // empty string
         assertFalse(Telegram.isValidTelegram(" ")); // spaces only
+        assertFalse(Telegram.isValidTelegram("he")); // <5 chars
+        assertFalse(Telegram.isValidTelegram("lo-pie")); // special chars that are not underscores
+        assertFalse(Telegram.isValidTelegram("lopi&e")); // special chars that are not underscores
 
-        // valid addresses
-        assertTrue(Telegram.isValidTelegram("fnnn"));
-        assertTrue(Telegram.isValidTelegram("-")); // one character
-        assertTrue(Telegram.isValidTelegram("jammy12")); // long address
+        // valid telegram
+        assertTrue(Telegram.isValidTelegram("fnnnn")); // exactly 5 chars
+        assertTrue(Telegram.isValidTelegram("jammy12")); // words and numbers
+        assertTrue(Telegram.isValidTelegram("JAMMdfg")); // caps
+        assertTrue(Telegram.isValidTelegram("12345")); // numbers
     }
 }

--- a/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
+++ b/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
@@ -30,6 +30,8 @@ public class TelegramTest {
         assertFalse(Telegram.isValidTelegram("he")); // <5 chars
         assertFalse(Telegram.isValidTelegram("lo-pie")); // special chars that are not underscores
         assertFalse(Telegram.isValidTelegram("lo__pie")); // consecutive underscores
+        assertFalse(Telegram.isValidTelegram("_lo_pie")); // starting with underscore
+        assertFalse(Telegram.isValidTelegram("lo_pie_")); // end with underscore
         assertFalse(Telegram.isValidTelegram("lopi&e")); // special chars that are not underscores
 
         // valid telegram

--- a/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
+++ b/src/test/java/seedu/masslinkers/model/student/TelegramTest.java
@@ -29,6 +29,7 @@ public class TelegramTest {
         assertFalse(Telegram.isValidTelegram(" ")); // spaces only
         assertFalse(Telegram.isValidTelegram("he")); // <5 chars
         assertFalse(Telegram.isValidTelegram("lo-pie")); // special chars that are not underscores
+        assertFalse(Telegram.isValidTelegram("lo__pie")); // consecutive underscores
         assertFalse(Telegram.isValidTelegram("lopi&e")); // special chars that are not underscores
 
         // valid telegram
@@ -36,5 +37,6 @@ public class TelegramTest {
         assertTrue(Telegram.isValidTelegram("jammy12")); // words and numbers
         assertTrue(Telegram.isValidTelegram("JAMMdfg")); // caps
         assertTrue(Telegram.isValidTelegram("12345")); // numbers
+        assertTrue(Telegram.isValidTelegram("lo_pie")); // an underscore
     }
 }

--- a/src/test/java/seedu/masslinkers/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/masslinkers/testutil/TypicalStudents.java
@@ -44,14 +44,14 @@ public class TypicalStudents {
             .withEmail("werner@example.com").withGitHub("goldl8ol").withTelegram("ellie")
             .withMods("CS2100", "CS1231S").build();
     public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withGitHub("EDXs").withTelegram("fionalim")
+            .withEmail("lydia@example.com").withGitHub("fiona").withTelegram("fionalim")
             .withMods("CS2100").build();
     public static final Student GEORGE = new StudentBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withTelegram("georgesim").withGitHub("pizzac0der")
             .withMods("CS2100").build();
 
     // Only optional fields filled
-    public static final Student TOM = new StudentBuilder().withName("Tom").withTelegram("tom").build();
+    public static final Student TOM = new StudentBuilder().withName("Tom").withTelegram("tommm").build();
 
     // Manually added
     public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
**Fixes #204** 
* Add a new check for GitHub usernames according to [this](https://github.com/shinnn/github-username-regex#:~:text=Github%20username%20may%20only%20contain,Maximum%20is%2039%20characters.)
* Modify test data and tests
* Update documentation

**Fixes #203** 
* Add a new check for Telegram handles according to their guidelines
* Modify test data and tests
* Update documentation

**Fixes #186** 
* Modify argument split to account for additional whitespace with `\\s+` in `ModCommandParser` and `AddInterestCommandParser` and `DeleteInterestCommandParser`
* Add tests to prevent similar bug

**Fixes #173** 
* Modify Java version in `fxml` files

<br>

**Fixes interests case sensitivity**
* Made interests completely case insensitive. Interests are displayed in lowercase, as indicated in UG
* Update documentation examples
